### PR TITLE
Expand backend API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-"# PersonalBanking" 
+# Family Credit Card Spend Tracker
+
+This project is a mobile-first application to track and analyze monthly credit card spending for family members. It uses a Flask backend with an Angular frontend. Transactions are parsed from uploaded PDF statements and organized with tags for flexible reporting.
+
+## Development Setup
+
+1. Install Python dependencies:
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+2. Initialize the database (uses SQLite by default):
+   ```bash
+   flask --app backend/app/main.py shell
+   >>> from app import db
+   >>> db.create_all()
+   ```
+3. Run the application:
+   ```bash
+   python backend/run.py
+   ```
+
+Basic API endpoints are available once the server is running:
+
+- `POST /auth/login` – obtain a JWT token
+- `GET /transactions` – list transactions
+- `POST /transactions` – create a transaction
+- `GET /tags` and `POST /tags`
+- `GET /cardholders` and `POST /cardholders`
+
+This repository contains an initial backend skeleton. Frontend code can be added under the `frontend/` directory following the structure in `AGENTS.md`.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,20 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_jwt_extended import JWTManager
+
+from .routes import register_blueprints
+
+
+db = SQLAlchemy()
+jwt = JWTManager()
+
+
+def create_app(config_object="app.config.Config"):
+    app = Flask(__name__)
+    app.config.from_object(config_object)
+
+    db.init_app(app)
+    jwt.init_app(app)
+    register_blueprints(app)
+
+    return app

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,6 @@
+import os
+
+class Config:
+    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///app.db")
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "change-me")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,12 @@
+from . import create_app, db
+
+app = create_app()
+
+
+@app.shell_context_processor
+def make_shell_context():
+    return {"db": db}
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,4 @@
+from .user import User
+from .cardholder import Cardholder
+from .tag import Tag
+from .transaction import Transaction

--- a/backend/app/models/cardholder.py
+++ b/backend/app/models/cardholder.py
@@ -1,0 +1,7 @@
+from .. import db
+
+class Cardholder(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), nullable=False)
+    color = db.Column(db.String(20))
+    transactions = db.relationship("Transaction", back_populates="cardholder")

--- a/backend/app/models/tag.py
+++ b/backend/app/models/tag.py
@@ -1,0 +1,7 @@
+from .. import db
+
+class Tag(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(50), nullable=False)
+    parent_id = db.Column(db.Integer, db.ForeignKey('tag.id'))
+    parent = db.relationship('Tag', remote_side=[id], backref='children')

--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from .. import db
+
+transaction_tags = db.Table(
+    'transaction_tags',
+    db.Column('transaction_id', db.Integer, db.ForeignKey('transaction.id')),
+    db.Column('tag_id', db.Integer, db.ForeignKey('tag.id'))
+)
+
+
+class Transaction(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    date = db.Column(db.Date, nullable=False)
+    description = db.Column(db.String(200), nullable=False)
+    amount = db.Column(db.Numeric(10, 2), nullable=False)
+    cardholder_id = db.Column(db.Integer, db.ForeignKey('cardholder.id'))
+    cardholder = db.relationship('Cardholder', back_populates='transactions')
+    tags = db.relationship('Tag', secondary=transaction_tags, backref='transactions')
+    source_file = db.Column(db.String(200))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,16 @@
+from werkzeug.security import generate_password_hash, check_password_hash
+
+from .. import db
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(20), default='admin')
+
+    def set_password(self, password):
+        self.password = generate_password_hash(password)
+
+    def check_password(self, password):
+        return check_password_hash(self.password, password)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,0 +1,13 @@
+from flask import Blueprint
+
+from .auth import bp as auth_bp
+from .transactions import bp as transactions_bp
+from .tags import bp as tags_bp
+from .cardholders import bp as cardholders_bp
+
+
+def register_blueprints(app):
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(transactions_bp)
+    app.register_blueprint(tags_bp)
+    app.register_blueprint(cardholders_bp)

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,0 +1,17 @@
+from flask import Blueprint, request, jsonify
+from werkzeug.security import check_password_hash
+from flask_jwt_extended import create_access_token
+
+from ..models import User
+
+bp = Blueprint('auth', __name__)
+
+
+@bp.route('/auth/login', methods=['POST'])
+def login():
+    data = request.get_json() or {}
+    user = User.query.filter_by(email=data.get('email')).first()
+    if user and check_password_hash(user.password, data.get('password', '')):
+        token = create_access_token(identity=user.id)
+        return jsonify({'access_token': token}), 200
+    return jsonify({'error': 'invalid credentials'}), 401

--- a/backend/app/routes/cardholders.py
+++ b/backend/app/routes/cardholders.py
@@ -1,0 +1,24 @@
+from flask import Blueprint, request, jsonify
+
+from .. import db
+from ..models import Cardholder
+
+bp = Blueprint('cardholders', __name__, url_prefix='/cardholders')
+
+
+@bp.route('', methods=['GET'])
+def list_cardholders():
+    cardholders = Cardholder.query.all()
+    return jsonify([
+        {'id': c.id, 'name': c.name, 'color': c.color}
+        for c in cardholders
+    ])
+
+
+@bp.route('', methods=['POST'])
+def create_cardholder():
+    payload = request.get_json() or {}
+    cardholder = Cardholder(name=payload['name'], color=payload.get('color'))
+    db.session.add(cardholder)
+    db.session.commit()
+    return jsonify({'id': cardholder.id}), 201

--- a/backend/app/routes/tags.py
+++ b/backend/app/routes/tags.py
@@ -1,0 +1,24 @@
+from flask import Blueprint, request, jsonify
+
+from .. import db
+from ..models import Tag
+
+bp = Blueprint('tags', __name__, url_prefix='/tags')
+
+
+@bp.route('', methods=['GET'])
+def list_tags():
+    tags = Tag.query.all()
+    return jsonify([
+        {'id': t.id, 'name': t.name, 'parent_id': t.parent_id}
+        for t in tags
+    ])
+
+
+@bp.route('', methods=['POST'])
+def create_tag():
+    payload = request.get_json() or {}
+    tag = Tag(name=payload['name'], parent_id=payload.get('parent_id'))
+    db.session.add(tag)
+    db.session.commit()
+    return jsonify({'id': tag.id}), 201

--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -1,0 +1,37 @@
+from datetime import date
+from flask import Blueprint, request, jsonify
+
+from .. import db
+from ..models import Transaction
+
+bp = Blueprint('transactions', __name__, url_prefix='/transactions')
+
+
+@bp.route('', methods=['GET'])
+def list_transactions():
+    transactions = Transaction.query.all()
+    data = [
+        {
+            'id': t.id,
+            'date': t.date.isoformat(),
+            'description': t.description,
+            'amount': float(t.amount),
+            'cardholder_id': t.cardholder_id,
+        }
+        for t in transactions
+    ]
+    return jsonify(data)
+
+
+@bp.route('', methods=['POST'])
+def create_transaction():
+    payload = request.get_json() or {}
+    transaction = Transaction(
+        date=date.fromisoformat(payload['date']),
+        description=payload['description'],
+        amount=payload['amount'],
+        cardholder_id=payload.get('cardholder_id'),
+    )
+    db.session.add(transaction)
+    db.session.commit()
+    return jsonify({'id': transaction.id}), 201

--- a/backend/app/services/pdf_parser.py
+++ b/backend/app/services/pdf_parser.py
@@ -1,0 +1,9 @@
+"""Stub for PDF parsing service."""
+
+def parse_pdf(file_path):
+    """Parse transactions from a PDF statement.
+
+    This is a placeholder implementation that returns an empty list. A real
+    parser would extract date, description, and amount for each transaction.
+    """
+    return []

--- a/backend/app/services/tagging.py
+++ b/backend/app/services/tagging.py
@@ -1,0 +1,7 @@
+"""Utilities for assigning and managing tags."""
+
+
+def assign_tags(transaction, keywords):
+    """Placeholder for tag assignment logic."""
+    # TODO: implement tagging based on keywords
+    return []

--- a/backend/app/utils/auth.py
+++ b/backend/app/utils/auth.py
@@ -1,0 +1,6 @@
+from flask_jwt_extended import create_access_token
+
+
+def generate_token(user_id):
+    """Generate a JWT for the given user ID."""
+    return create_access_token(identity=user_id)

--- a/backend/app/utils/response.py
+++ b/backend/app/utils/response.py
@@ -1,0 +1,9 @@
+from flask import jsonify
+
+
+def ok(data, status=200):
+    return jsonify(data), status
+
+
+def error(message, status=400):
+    return jsonify({'error': message}), status

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+flask
+flask-sqlalchemy
+flask-jwt-extended
+flask-migrate
+psycopg2-binary

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,0 +1,4 @@
+from app.main import app
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary
- add CRUD routes for transactions, tags, and cardholders
- implement JWT login logic
- include helper services and utilities
- update README with setup and API info

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_687c2f9064248320908ad22ed9f53924