### PR TITLE
Fix routes blueprint function

### DIFF
--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,12 +1,14 @@
 from flask import Blueprint
 
 from .auth import bp as auth_bp
-
 from .transactions import bp as transactions_bp
 from .tags import bp as tags_bp
 from .cardholders import bp as cardholders_bp
 
-def register_blueprints(<<<< 1uru9u-codex/assist-with-task
+
+def register_blueprints(app: Blueprint) -> None:
+    """Register all route blueprints with the given Flask app."""
+    app.register_blueprint(auth_bp)
     app.register_blueprint(transactions_bp)
     app.register_blueprint(tags_bp)
     app.register_blueprint(cardholders_bp)


### PR DESCRIPTION
## Summary
- fix truncated `register_blueprints` definition

## Testing
- `python3 -m py_compile backend/app/routes/__init__.py`
- `find backend -name '*.py' | xargs python3 -m py_compile` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_687cae9993108320affcbe145734ea4e