### PR TITLE
Fix circular import in Flask app initialization

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -2,11 +2,10 @@ from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_jwt_extended import JWTManager
 
-from .routes import register_blueprints
-
-
 db = SQLAlchemy()
 jwt = JWTManager()
+
+from .routes import register_blueprints
 
 
 def create_app(config_object="app.config.Config"):


### PR DESCRIPTION
## Summary
- avoid circular import by defining `db` and `jwt` before importing routes

## Testing
- `pip install -r backend/requirements.txt` *(fails: Tunnel connection failed)*
- `python backend/run.py` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_687cb4daf8c883209bfca3b97cae88c9