### PR TITLE
Add basic home page and PDF upload

### DIFF
--- a/backend/app/services/pdf_parser.py
+++ b/backend/app/services/pdf_parser.py
@@ -1,9 +1,20 @@
-"""Stub for PDF parsing service."""
+"""Utilities for parsing uploaded PDF statements."""
+
+from datetime import date
+
 
 def parse_pdf(file_path):
     """Parse transactions from a PDF statement.
 
-    This is a placeholder implementation that returns an empty list. A real
-    parser would extract date, description, and amount for each transaction.
+    This is a placeholder implementation that simply returns a single
+    transaction. Real logic would use a library such as ``pdfminer.six`` to
+    extract data from the PDF file.
     """
-    return []
+
+    return [
+        {
+            "date": date.today(),
+            "description": "Placeholder transaction",
+            "amount": 0.0,
+        }
+    ]

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { Upload } from './pages/upload/upload';
 import { Transactions } from './pages/transactions/transactions';
 import { Tags } from './pages/tags/tags';
 import { Report } from './pages/report/report';
+import { Home } from './pages/home/home';
 
 export const routes: Routes = [
   { path: 'login', component: Login },
@@ -13,5 +14,5 @@ export const routes: Routes = [
   { path: 'transactions', component: Transactions },
   { path: 'tags', component: Tags },
   { path: 'report/:month', component: Report },
-  { path: '', redirectTo: 'dashboard', pathMatch: 'full' }
+  { path: '', component: Home }
 ];

--- a/frontend/src/app/pages/home/home.html
+++ b/frontend/src/app/pages/home/home.html
@@ -1,0 +1,6 @@
+<div class="container mt-5 text-center">
+  <h1>Welcome to Family Credit Tracker</h1>
+  <p class="mt-3">
+    <a routerLink="/login" class="btn btn-primary">Login</a>
+  </p>
+</div>

--- a/frontend/src/app/pages/home/home.scss
+++ b/frontend/src/app/pages/home/home.scss
@@ -1,0 +1,1 @@
+/* Styles for home page */

--- a/frontend/src/app/pages/home/home.ts
+++ b/frontend/src/app/pages/home/home.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-home',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './home.html',
+  styleUrl: './home.scss'
+})
+export class Home {}

--- a/frontend/src/app/pages/transactions/transactions.html
+++ b/frontend/src/app/pages/transactions/transactions.html
@@ -1,1 +1,21 @@
-<p>transactions works!</p>
+<div class="container mt-4">
+  <h2>Transactions</h2>
+  <table class="table table-striped" *ngIf="transactions.length">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Description</th>
+        <th>Amount</th>
+        <th>Cardholder</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let t of transactions">
+        <td>{{ t.date }}</td>
+        <td>{{ t.description }}</td>
+        <td>{{ t.amount }}</td>
+        <td>{{ t.cardholder_id }}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/frontend/src/app/pages/transactions/transactions.ts
+++ b/frontend/src/app/pages/transactions/transactions.ts
@@ -1,13 +1,22 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 
 @Component({
   selector: 'app-transactions',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, HttpClientModule],
   templateUrl: './transactions.html',
   styleUrl: './transactions.scss'
 })
-export class Transactions {
+export class Transactions implements OnInit {
+  transactions: any[] = [];
 
+  constructor(private http: HttpClient) {}
+
+  ngOnInit(): void {
+    this.http.get<any[]>('/transactions').subscribe(res => {
+      this.transactions = res;
+    });
+  }
 }

--- a/frontend/src/app/pages/upload/upload.html
+++ b/frontend/src/app/pages/upload/upload.html
@@ -1,1 +1,4 @@
-<p>upload works!</p>
+<div class="container mt-4">
+  <h2>Upload PDF Statement</h2>
+  <input type="file" (change)="onFileSelected($event)" />
+</div>

--- a/frontend/src/app/pages/upload/upload.ts
+++ b/frontend/src/app/pages/upload/upload.ts
@@ -1,13 +1,30 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-upload',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, HttpClientModule],
   templateUrl: './upload.html',
   styleUrl: './upload.scss'
 })
 export class Upload {
+  constructor(private http: HttpClient, private router: Router) {}
 
+  onFileSelected(event: Event) {
+    const input = event.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) {
+      return;
+    }
+
+    const file = input.files[0];
+    const formData = new FormData();
+    formData.append('file', file);
+
+    this.http.post('/transactions/upload_pdf', formData).subscribe(() => {
+      this.router.navigate(['/transactions']);
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- implement placeholder PDF parser and `/transactions/upload_pdf` endpoint
- add Angular home page
- enhance file upload page to send file to backend
- display transactions list
- update routing to use home page as default

## Testing
- `python -m py_compile backend/app/routes/transactions.py backend/app/services/pdf_parser.py`
- `npx ng build` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_b_687ce7b900088320abe54c5df7863ffa