### PR TITLE
Fix router duplication error

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -1,9 +1,0 @@
-import { NgModule } from '@angular/core';
-import { RouterModule } from '@angular/router';
-import { routes } from './app.routes';
-
-@NgModule({
-  imports: [RouterModule.forRoot(routes)],
-  exports: [RouterModule]
-})
-export class AppRoutingModule {}

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,10 +1,9 @@
 import { Component, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { AppRoutingModule } from './app-routing.module';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, AppRoutingModule],
+  imports: [RouterOutlet],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })


### PR DESCRIPTION
## Summary
- remove unused `AppRoutingModule`
- stop providing router twice

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687cef1a8a3c8320a554074b9d00dfe4