### PR TITLE
Fix Angular API URLs

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_jwt_extended import JWTManager
+from flask_cors import CORS
 
 db = SQLAlchemy()
 jwt = JWTManager()
@@ -11,6 +12,9 @@ from .routes import register_blueprints
 def create_app(config_object="app.config.Config"):
     app = Flask(__name__)
     app.config.from_object(config_object)
+
+    # Enable CORS for all routes to allow the Angular frontend to access the API
+    CORS(app)
 
     db.init_app(app)
     jwt.init_app(app)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ flask-sqlalchemy
 flask-jwt-extended
 flask-migrate
 psycopg2-binary
+flask-cors

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -36,6 +36,12 @@
           },
           "configurations": {
             "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
               "budgets": [
                 {
                   "type": "initial",
@@ -53,7 +59,8 @@
             "development": {
               "optimization": false,
               "extractLicenses": false,
-              "sourceMap": true
+              "sourceMap": true,
+              "fileReplacements": []
             }
           },
           "defaultConfiguration": "production"

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 import { tap } from 'rxjs/operators';
 
 @Injectable({ providedIn: 'root' })
@@ -10,7 +11,7 @@ export class AuthService {
 
   login(email: string, password: string) {
     return this.http.post<{access_token: string}>(
-      '/auth/login',
+      `${environment.apiUrl}/auth/login`,
       { email, password }
     ).pipe(
       tap(res => {

--- a/frontend/src/app/services/data.service.ts
+++ b/frontend/src/app/services/data.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class DataService {
   constructor(private http: HttpClient) {}
 
   getTransactions() {
-    return this.http.get<any[]>('/transactions');
+    return this.http.get<any[]>(`${environment.apiUrl}/transactions`);
   }
 }

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  apiUrl: 'http://localhost:5000'
+};

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  apiUrl: 'http://localhost:5000'
+};


### PR DESCRIPTION
## Summary
- configure environment API URL
- use API base URL in auth and data services
- setup file replacements for production builds
- enable CORS in Flask backend

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_687cf131c9a8832099a1bd6cd6c70715