### PR TITLE
Add register endpoint and frontend page

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -6,6 +6,8 @@ from .. import db
 
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80))
+    username = db.Column(db.String(80), unique=True)
     email = db.Column(db.String(120), unique=True, nullable=False)
     password = db.Column(db.String(128), nullable=False)
 

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -3,6 +3,7 @@ from flask import Blueprint, request, jsonify
 from werkzeug.security import check_password_hash
 from flask_jwt_extended import create_access_token
 
+from .. import db
 from ..models import User
  
 
@@ -18,3 +19,18 @@ def login():
         token = create_access_token(identity=user.id)
         return jsonify({'access_token': token}), 200
     return jsonify({'error': 'invalid credentials'}), 401
+
+
+@bp.route('/auth/register', methods=['POST'])
+def register():
+    """Register a new user."""
+    payload = request.get_json() or {}
+    user = User(
+        name=payload.get('name'),
+        username=payload.get('username'),
+        email=payload.get('email'),
+    )
+    user.set_password(payload.get('password', ''))
+    db.session.add(user)
+    db.session.commit()
+    return jsonify({'id': user.id}), 201

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -6,9 +6,11 @@ import { Transactions } from './pages/transactions/transactions';
 import { Tags } from './pages/tags/tags';
 import { Report } from './pages/report/report';
 import { Home } from './pages/home/home';
+import { Register } from './pages/register/register';
 
 export const routes: Routes = [
   { path: 'login', component: Login },
+  { path: 'register', component: Register },
   { path: 'dashboard', component: Dashboard },
   { path: 'upload', component: Upload },
   { path: 'transactions', component: Transactions },

--- a/frontend/src/app/pages/register/register.html
+++ b/frontend/src/app/pages/register/register.html
@@ -1,0 +1,21 @@
+<div class="container mt-5">
+  <form [formGroup]="form" (ngSubmit)="submit()" class="w-100" style="max-width: 300px;">
+    <div class="mb-3">
+      <label class="form-label">Name</label>
+      <input class="form-control" formControlName="name" type="text" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Username</label>
+      <input class="form-control" formControlName="username" type="text" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Email</label>
+      <input class="form-control" formControlName="email" type="email" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Password</label>
+      <input class="form-control" formControlName="password" type="password" />
+    </div>
+    <button class="btn btn-primary" type="submit">Register</button>
+  </form>
+</div>

--- a/frontend/src/app/pages/register/register.ts
+++ b/frontend/src/app/pages/register/register.ts
@@ -1,0 +1,32 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup } from '@angular/forms';
+import { Router } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-register',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './register.html',
+  styleUrl: './register.scss'
+})
+export class Register {
+  form: FormGroup;
+
+  constructor(private fb: FormBuilder, private auth: AuthService, private router: Router) {
+    this.form = this.fb.nonNullable.group({
+      name: '',
+      username: '',
+      email: '',
+      password: ''
+    });
+  }
+
+  submit() {
+    const { name, username, email, password } = this.form.getRawValue();
+    this.auth.register({ name, username, email, password }).subscribe({
+      next: () => this.router.navigate(['/login'])
+    });
+  }
+}

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -20,6 +20,13 @@ export class AuthService {
     );
   }
 
+  register(data: { name?: string; username?: string; email: string; password: string }) {
+    return this.http.post<{id: number}>(
+      `${environment.apiUrl}/auth/register`,
+      data
+    );
+  }
+
   get token(): string | null {
     return localStorage.getItem(this.tokenKey);
   }


### PR DESCRIPTION
## Summary
- extend user model with optional name and username columns
- add `/auth/register` backend route
- wire new Angular Register page with reactive form
- allow AuthService to POST registrations
- expose registration route in Angular routing

## Testing
- `npm test --silent -- --watch=false` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_b_687d0ac3581c8320a37927a19fc1e943