### PR TITLE
Add manual transaction entry page

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { Login } from './pages/login/login';
 import { Dashboard } from './pages/dashboard/dashboard';
 import { Upload } from './pages/upload/upload';
 import { Transactions } from './pages/transactions/transactions';
+import { AddTransaction } from './pages/add-transaction/add-transaction';
 import { Tags } from './pages/tags/tags';
 import { Report } from './pages/report/report';
 import { Home } from './pages/home/home';
@@ -11,6 +12,7 @@ export const routes: Routes = [
   { path: 'login', component: Login },
   { path: 'dashboard', component: Dashboard },
   { path: 'upload', component: Upload },
+  { path: 'transactions/new', component: AddTransaction },
   { path: 'transactions', component: Transactions },
   { path: 'tags', component: Tags },
   { path: 'report/:month', component: Report },

--- a/frontend/src/app/pages/add-transaction/add-transaction.html
+++ b/frontend/src/app/pages/add-transaction/add-transaction.html
@@ -1,0 +1,22 @@
+<div class="container mt-4">
+  <h2>Add Transaction</h2>
+  <form [formGroup]="form" (ngSubmit)="submit()" class="mt-3" style="max-width: 400px;">
+    <div class="mb-3">
+      <label class="form-label">Date</label>
+      <input type="date" class="form-control" formControlName="date" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Description</label>
+      <input type="text" class="form-control" formControlName="description" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Amount</label>
+      <input type="number" class="form-control" formControlName="amount" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Cardholder ID</label>
+      <input type="number" class="form-control" formControlName="cardholder_id" />
+    </div>
+    <button class="btn btn-primary" type="submit">Save</button>
+  </form>
+</div>

--- a/frontend/src/app/pages/add-transaction/add-transaction.ts
+++ b/frontend/src/app/pages/add-transaction/add-transaction.ts
@@ -1,0 +1,32 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup } from '@angular/forms';
+import { Router } from '@angular/router';
+import { DataService } from '../../services/data.service';
+
+@Component({
+  selector: 'app-add-transaction',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './add-transaction.html',
+  styleUrl: './add-transaction.scss'
+})
+export class AddTransaction {
+  form: FormGroup;
+
+  constructor(private fb: FormBuilder, private data: DataService, private router: Router) {
+    this.form = this.fb.nonNullable.group({
+      date: '',
+      description: '',
+      amount: 0,
+      cardholder_id: ''
+    });
+  }
+
+  submit() {
+    const payload = this.form.getRawValue();
+    this.data.createTransaction(payload).subscribe(() => {
+      this.router.navigate(['/transactions']);
+    });
+  }
+}

--- a/frontend/src/app/pages/dashboard/dashboard.html
+++ b/frontend/src/app/pages/dashboard/dashboard.html
@@ -1,3 +1,7 @@
 <div class="container mt-4">
+  <div class="mb-3">
+    <a routerLink="/upload" class="btn btn-primary me-2">Upload Statement</a>
+    <a routerLink="/transactions/new" class="btn btn-secondary">Add Transaction</a>
+  </div>
   <canvas id="summaryChart"></canvas>
 </div>

--- a/frontend/src/app/services/data.service.ts
+++ b/frontend/src/app/services/data.service.ts
@@ -9,4 +9,8 @@ export class DataService {
   getTransactions() {
     return this.http.get<any[]>(`${environment.apiUrl}/transactions`);
   }
+
+  createTransaction(payload: any) {
+    return this.http.post(`${environment.apiUrl}/transactions`, payload);
+  }
 }


### PR DESCRIPTION
## Summary
- provide buttons on dashboard to upload statements and add new transactions
- add AddTransaction component with form
- add createTransaction() to DataService
- wire up new route `/transactions/new`

## Testing
- `npm test --silent -- --watch=false` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_b_687d0ac5c2408320920319e2ec875564