### PR TITLE
Add expandable transaction table component

### DIFF
--- a/frontend/src/app/components/transaction-table/transaction-table.html
+++ b/frontend/src/app/components/transaction-table/transaction-table.html
@@ -1,0 +1,42 @@
+<div class="table-responsive">
+  <table class="table table-striped align-middle">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Description</th>
+        <th>Cardholder</th>
+        <th class="text-end">Total</th>
+      </tr>
+    </thead>
+    <tbody>
+      <ng-container *ngFor="let tx of transactions; let i = index">
+        <tr (click)="tx.components && toggle(i)" [class.table-active]="expanded[i]">
+          <td>{{ tx.transaction_date }}</td>
+          <td>{{ tx.description }}</td>
+          <td>{{ tx.cardholder_name }}</td>
+          <td class="text-end">{{ tx.total_amount | currency }}</td>
+        </tr>
+        <tr *ngIf="tx.components && expanded[i]">
+          <td colspan="4" class="p-0">
+            <table class="table mb-0">
+              <thead>
+                <tr>
+                  <th>Label</th>
+                  <th>Amount</th>
+                  <th>VAT</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr *ngFor="let c of tx.components">
+                  <td>{{ c.label }}</td>
+                  <td>{{ c.amount | currency }}</td>
+                  <td>{{ c.vat | currency }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </ng-container>
+    </tbody>
+  </table>
+</div>

--- a/frontend/src/app/components/transaction-table/transaction-table.scss
+++ b/frontend/src/app/components/transaction-table/transaction-table.scss
@@ -1,0 +1,11 @@
+.table-responsive {
+  overflow-x: auto;
+}
+
+.table tbody tr {
+  cursor: pointer;
+}
+
+.table-active {
+  background-color: #f8f9fa;
+}

--- a/frontend/src/app/components/transaction-table/transaction-table.ts
+++ b/frontend/src/app/components/transaction-table/transaction-table.ts
@@ -1,0 +1,60 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+interface TransactionComponent {
+  label: string;
+  amount: number;
+  vat: number;
+}
+
+interface Transaction {
+  transaction_date: string;
+  description: string;
+  cardholder_name: string;
+  total_amount: number;
+  components?: TransactionComponent[];
+}
+
+@Component({
+  selector: 'app-transaction-table',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './transaction-table.html',
+  styleUrl: './transaction-table.scss'
+})
+export class TransactionTable {
+  transactions: Transaction[] = [
+    {
+      transaction_date: '2024-06-01',
+      description: 'Online Purchase',
+      cardholder_name: 'John',
+      total_amount: 120,
+      components: [
+        { label: 'Item Total', amount: 100, vat: 20 },
+        { label: 'Shipping', amount: 20, vat: 0 }
+      ]
+    },
+    {
+      transaction_date: '2024-06-03',
+      description: 'Grocery Store',
+      cardholder_name: 'Mary',
+      total_amount: 45
+    },
+    {
+      transaction_date: '2024-06-04',
+      description: 'Restaurant',
+      cardholder_name: 'John',
+      total_amount: 75,
+      components: [
+        { label: 'Meals', amount: 60, vat: 10 },
+        { label: 'Service', amount: 15, vat: 0 }
+      ]
+    }
+  ];
+
+  expanded: { [key: number]: boolean } = {};
+
+  toggle(index: number) {
+    this.expanded[index] = !this.expanded[index];
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone `TransactionTable` component with sample data
- show an expandable table with sub-fees

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_b_687dbb0d894c8320940e235308d49962