### PR TITLE
Update frontend API calls to use environment

### DIFF
--- a/frontend/src/app/pages/transactions/transactions.ts
+++ b/frontend/src/app/pages/transactions/transactions.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-transactions',
@@ -15,7 +16,7 @@ export class Transactions implements OnInit {
   constructor(private http: HttpClient) {}
 
   ngOnInit(): void {
-    this.http.get<any[]>('/transactions').subscribe(res => {
+    this.http.get<any[]>(`${environment.apiUrl}/transactions`).subscribe(res => {
       this.transactions = res;
     });
   }

--- a/frontend/src/app/pages/upload/upload.ts
+++ b/frontend/src/app/pages/upload/upload.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { Router } from '@angular/router';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-upload',
@@ -23,7 +24,7 @@ export class Upload {
     const formData = new FormData();
     formData.append('file', file);
 
-    this.http.post('/transactions/upload_pdf', formData).subscribe(() => {
+    this.http.post(`${environment.apiUrl}/transactions/upload_pdf`, formData).subscribe(() => {
       this.router.navigate(['/transactions']);
     });
   }


### PR DESCRIPTION
## Summary
- update upload page to post to `environment.apiUrl`
- update transactions page to get from `environment.apiUrl`

## Testing
- `npx ng test --no-watch --browsers=ChromeHeadless` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_b_687e31573fb48320bc8693ca19d5bf8d