### PR TITLE
Fix upload_pdf field mapping

### DIFF
--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -53,9 +53,9 @@ def upload_pdf():
     created = 0
     for data in transactions:
         transaction = Transaction(
-            date=data['date'],
+            date=data['transaction_date'],
             description=data['description'],
-            amount=data['amount'],
+            amount=data['total_amount'],
             cardholder_id=data.get('cardholder_id'),
             source_file=file.filename,
         )


### PR DESCRIPTION
## Summary
- map fields from `parse_pdf` output when creating transactions

## Testing
- `python -m compileall backend/app`

------
https://chatgpt.com/codex/tasks/task_b_687e315be2248320a1a7942362c85319