### PR TITLE
Handle optional source_file when adding transactions

### DIFF
--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -33,6 +33,7 @@ def create_transaction():
         description=payload['description'],
         amount=payload['amount'],
         cardholder_id=payload.get('cardholder_id'),
+        source_file=payload.get('source_file'),
     )
     db.session.add(transaction)
     db.session.commit()

--- a/frontend/src/app/pages/add-transaction/add-transaction.html
+++ b/frontend/src/app/pages/add-transaction/add-transaction.html
@@ -17,6 +17,10 @@
       <label class="form-label">Cardholder ID</label>
       <input type="number" class="form-control" formControlName="cardholder_id" />
     </div>
+    <div class="mb-3">
+      <label class="form-label">Source File</label>
+      <input type="text" class="form-control" formControlName="source_file" />
+    </div>
     <button class="btn btn-primary" type="submit">Save</button>
   </form>
 </div>

--- a/frontend/src/app/pages/add-transaction/add-transaction.ts
+++ b/frontend/src/app/pages/add-transaction/add-transaction.ts
@@ -19,7 +19,8 @@ export class AddTransaction {
       date: '',
       description: '',
       amount: 0,
-      cardholder_id: ''
+      cardholder_id: '',
+      source_file: ''
     });
   }
 


### PR DESCRIPTION
## Summary
- allow specifying a PDF source file when adding a transaction
- persist `source_file` in backend when provided

## Testing
- `python -m pytest`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_687e3158a6688320a0c750b0f004cad0