### PR TITLE
Fix app spec by rendering title

### DIFF
--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,1 +1,2 @@
+<h1>Hello, {{ title() }}</h1>
 <router-outlet />


### PR DESCRIPTION
## Summary
- display `title` in the root app template so the spec sees the `<h1>`

## Testing
- `npm test` *(fails: cannot start Chrome)*

------
https://chatgpt.com/codex/tasks/task_b_687e315e3f808320b0334915edcfabb5