### PR TITLE
Add logout navigation

### DIFF
--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,1 +1,9 @@
+<nav class="navbar navbar-expand navbar-light bg-light px-3">
+  <a class="navbar-brand" routerLink="/">Home</a>
+  <ul class="navbar-nav ms-auto">
+    <li class="nav-item">
+      <a class="nav-link" (click)="logout()" style="cursor: pointer">Logout</a>
+    </li>
+  </ul>
+</nav>
 <router-outlet />

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,12 +1,20 @@
 import { Component, signal } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { RouterOutlet, RouterModule } from '@angular/router';
+import { AuthService } from './services/auth.service';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  standalone: true,
+  imports: [RouterOutlet, RouterModule],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })
 export class App {
   protected readonly title = signal('frontend');
+
+  constructor(private auth: AuthService) {}
+
+  logout(): void {
+    this.auth.logout();
+  }
 }

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { Router } from '@angular/router';
 import { environment } from '../../environments/environment';
 import { tap } from 'rxjs/operators';
 
@@ -7,7 +8,7 @@ import { tap } from 'rxjs/operators';
 export class AuthService {
   private tokenKey = 'jwt_token';
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private router: Router) {}
 
   login(email: string, password: string) {
     return this.http.post<{access_token: string}>(
@@ -25,6 +26,13 @@ export class AuthService {
       `${environment.apiUrl}/auth/register`,
       data
     );
+  }
+
+  logout(redirect: boolean = true): void {
+    localStorage.removeItem(this.tokenKey);
+    if (redirect) {
+      this.router.navigate(['/login']);
+    }
   }
 
   get token(): string | null {


### PR DESCRIPTION
## Summary
- implement `logout()` method in `AuthService`
- add navigation bar with logout link
- invoke the service from the root component

## Testing
- `npm install`
- `npm test` *(fails: no Chrome binary in environment)*

------
https://chatgpt.com/codex/tasks/task_b_687e31568bb48320ac81ef856218f3c6