### PR TITLE
Add tag manager frontend and update API

### DIFF
--- a/backend/app/routes/tags.py
+++ b/backend/app/routes/tags.py
@@ -22,3 +22,25 @@ def create_tag():
     db.session.add(tag)
     db.session.commit()
     return jsonify({'id': tag.id}), 201
+
+
+@bp.route('/<int:tag_id>', methods=['PATCH'])
+def update_tag(tag_id: int):
+    """Update an existing tag."""
+    tag = Tag.query.get_or_404(tag_id)
+    payload = request.get_json() or {}
+    if 'name' in payload:
+        tag.name = payload['name']
+    if 'parent_id' in payload:
+        tag.parent_id = payload['parent_id']
+    db.session.commit()
+    return jsonify({'id': tag.id})
+
+
+@bp.route('/<int:tag_id>', methods=['DELETE'])
+def delete_tag(tag_id: int):
+    """Remove a tag."""
+    tag = Tag.query.get_or_404(tag_id)
+    db.session.delete(tag)
+    db.session.commit()
+    return jsonify({'status': 'deleted'})

--- a/frontend/src/app/components/tag-tree/tag-tree.html
+++ b/frontend/src/app/components/tag-tree/tag-tree.html
@@ -1,0 +1,12 @@
+<ul class="list-unstyled ms-3">
+  <li *ngFor="let tag of tags" class="mb-1">
+    <div class="d-flex align-items-center">
+      <input type="checkbox" class="form-check-input me-2" [checked]="selected.includes(tag.id)" (change)="toggle(tag.id)" />
+      <span class="flex-grow-1">{{ tag.name }}</span>
+      <button class="btn btn-sm btn-secondary me-1" (click)="edit.emit(tag)">Edit</button>
+      <button class="btn btn-sm btn-danger" (click)="remove.emit(tag)">Delete</button>
+    </div>
+    <app-tag-tree *ngIf="tag.children?.length" [tags]="tag.children" [selected]="selected"
+                  (selectedChange)="selectedChange.emit($event)" (edit)="edit.emit($event)" (remove)="remove.emit($event)"></app-tag-tree>
+  </li>
+</ul>

--- a/frontend/src/app/components/tag-tree/tag-tree.scss
+++ b/frontend/src/app/components/tag-tree/tag-tree.scss
@@ -1,0 +1,1 @@
+/* empty placeholder */

--- a/frontend/src/app/components/tag-tree/tag-tree.ts
+++ b/frontend/src/app/components/tag-tree/tag-tree.ts
@@ -1,0 +1,27 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Tag } from '../../models/tag';
+
+@Component({
+  selector: 'app-tag-tree',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './tag-tree.html',
+  styleUrl: './tag-tree.scss'
+})
+export class TagTree {
+  @Input() tags: Tag[] = [];
+  @Input() selected: number[] = [];
+  @Output() selectedChange = new EventEmitter<number[]>();
+  @Output() edit = new EventEmitter<Tag>();
+  @Output() remove = new EventEmitter<Tag>();
+
+  toggle(id: number) {
+    if (this.selected.includes(id)) {
+      this.selected = this.selected.filter(t => t !== id);
+    } else {
+      this.selected = [...this.selected, id];
+    }
+    this.selectedChange.emit(this.selected);
+  }
+}

--- a/frontend/src/app/models/tag.ts
+++ b/frontend/src/app/models/tag.ts
@@ -1,0 +1,6 @@
+export interface Tag {
+  id: number;
+  name: string;
+  parent_id?: number | null;
+  children?: Tag[];
+}

--- a/frontend/src/app/pages/tags/tags.html
+++ b/frontend/src/app/pages/tags/tags.html
@@ -1,1 +1,35 @@
-<p>tags works!</p>
+<div class="container mt-4">
+  <h2>Tags</h2>
+  <button class="btn btn-primary mb-2" (click)="open()">Add Tag</button>
+  <app-tag-tree [tags]="tags" [(selected)]="selected" (edit)="open($event)" (remove)="remove($event)"></app-tag-tree>
+</div>
+
+<div class="modal fade show" tabindex="-1" [ngStyle]="{display: showModal ? 'block' : 'none'}" *ngIf="showModal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">{{ editTag ? 'Edit Tag' : 'Add Tag' }}</h5>
+        <button type="button" class="btn-close" (click)="showModal = false"></button>
+      </div>
+      <div class="modal-body">
+        <form [formGroup]="form" class="mb-0">
+          <div class="mb-3">
+            <label class="form-label">Name</label>
+            <input class="form-control" formControlName="name" />
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Parent</label>
+            <select class="form-select" formControlName="parent_id">
+              <option value="">-- none --</option>
+              <option *ngFor="let t of flatTags" [value]="t.id">{{ t.name }}</option>
+            </select>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" (click)="showModal = false">Cancel</button>
+        <button class="btn btn-primary" (click)="save()">Save</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/pages/tags/tags.ts
+++ b/frontend/src/app/pages/tags/tags.ts
@@ -1,13 +1,88 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
+import { ReactiveFormsModule, FormBuilder, FormGroup } from '@angular/forms';
+import { TagService } from '../../services/tag.service';
+import { Tag } from '../../models/tag';
+import { TagTree } from '../../components/tag-tree/tag-tree';
 
 @Component({
   selector: 'app-tags',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, HttpClientModule, ReactiveFormsModule, TagTree],
   templateUrl: './tags.html',
   styleUrl: './tags.scss'
 })
-export class Tags {
+export class Tags implements OnInit {
+  tags: Tag[] = [];
+  flatTags: Tag[] = [];
+  selected: number[] = [];
 
+  showModal = false;
+  editTag?: Tag;
+  form: FormGroup;
+
+  constructor(private service: TagService, private fb: FormBuilder) {
+    this.form = this.fb.nonNullable.group({
+      name: '',
+      parent_id: '' as any
+    });
+  }
+
+  ngOnInit() {
+    this.load();
+  }
+
+  load() {
+    this.service.getTags().subscribe(res => {
+      this.flatTags = res;
+      this.tags = this.buildTree(res);
+    });
+  }
+
+  buildTree(list: Tag[]): Tag[] {
+    const map: Record<number, Tag & {children: Tag[]}> = {};
+    for (const t of list) {
+      map[t.id] = { ...t, children: [] };
+    }
+    const roots: Tag[] = [];
+    for (const t of Object.values(map)) {
+      if (t.parent_id && map[t.parent_id]) {
+        map[t.parent_id].children.push(t);
+      } else {
+        roots.push(t);
+      }
+    }
+    return roots;
+  }
+
+  open(tag?: Tag) {
+    this.editTag = tag;
+    this.form.setValue({
+      name: tag?.name || '',
+      parent_id: tag?.parent_id ?? ''
+    });
+    this.showModal = true;
+  }
+
+  save() {
+    const data = this.form.getRawValue();
+    if (this.editTag) {
+      this.service.updateTag(this.editTag.id, data).subscribe(() => {
+        this.showModal = false;
+        this.load();
+      });
+    } else {
+      this.service.createTag(data).subscribe(() => {
+        this.showModal = false;
+        this.load();
+      });
+    }
+  }
+
+  remove(tag: Tag) {
+    if (confirm('Delete tag?')) {
+      this.service.deleteTag(tag.id).subscribe(() => this.load());
+    }
+  }
 }

--- a/frontend/src/app/services/tag.service.ts
+++ b/frontend/src/app/services/tag.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Tag } from '../models/tag';
+
+@Injectable({ providedIn: 'root' })
+export class TagService {
+  constructor(private http: HttpClient) {}
+
+  getTags() {
+    return this.http.get<Tag[]>(`${environment.apiUrl}/tags`);
+  }
+
+  createTag(payload: Partial<Tag>) {
+    return this.http.post<{id: number}>(`${environment.apiUrl}/tags`, payload);
+  }
+
+  updateTag(id: number, payload: Partial<Tag>) {
+    return this.http.patch(`${environment.apiUrl}/tags/${id}`, payload);
+  }
+
+  deleteTag(id: number) {
+    return this.http.delete(`${environment.apiUrl}/tags/${id}`);
+  }
+}


### PR DESCRIPTION
## Summary
- extend backend tag routes with PATCH and DELETE
- create Tag model and service on the Angular side
- build TagTree component for displaying hierarchical tags
- implement tag management page with modal editing and multi-select tree

## Testing
- `python -m py_compile backend/app/routes/tags.py`


------
https://chatgpt.com/codex/tasks/task_b_687e4196bd0c83209f2a7e41dc03abc6