### PR TITLE
Add dashboard charts with filtering

### DIFF
--- a/frontend/src/app/pages/dashboard/dashboard.html
+++ b/frontend/src/app/pages/dashboard/dashboard.html
@@ -3,5 +3,12 @@
     <a routerLink="/upload" class="btn btn-primary me-2">Upload Statement</a>
     <a routerLink="/transactions/new" class="btn btn-secondary">Add Transaction</a>
   </div>
-  <canvas id="summaryChart"></canvas>
+  <div class="row">
+    <div class="col-md-6 mb-4">
+      <canvas id="categoryChart"></canvas>
+    </div>
+    <div class="col-md-6 mb-4">
+      <canvas id="monthlyChart"></canvas>
+    </div>
+  </div>
 </div>

--- a/frontend/src/app/pages/dashboard/dashboard.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
 import { DataService } from '../../services/data.service';
 import Chart from 'chart.js/auto';
 
@@ -11,22 +12,67 @@ import Chart from 'chart.js/auto';
   styleUrl: './dashboard.scss'
 })
 export class Dashboard implements OnInit {
-  constructor(private data: DataService) {}
+  constructor(private data: DataService, private router: Router) {}
 
   ngOnInit(): void {
-    this.data.getTransactions().subscribe(trans => {
-      const totals: { [key: string]: number } = {};
-      for (const t of trans as any[]) {
-        const key = t.cardholder_id ?? 'other';
-        totals[key] = (totals[key] || 0) + t.amount;
+    this.data.getTransactions().subscribe(transactions => {
+      const categoryTotals: { [key: string]: number } = {};
+      const monthTotals: { [key: string]: number } = {};
+
+      for (const tx of transactions as any[]) {
+        const month = (tx.date as string).slice(0, 7);
+        monthTotals[month] = (monthTotals[month] || 0) + tx.amount;
+
+        const cat = (tx.tags && tx.tags.length)
+          ? tx.tags[0].name
+          : 'Uncategorized';
+        categoryTotals[cat] = (categoryTotals[cat] || 0) + tx.amount;
       }
-      new Chart('summaryChart', {
-        type: 'bar',
-        data: {
-          labels: Object.keys(totals),
-          datasets: [{ data: Object.values(totals), label: 'Spend' }]
+
+      this.renderCategoryChart(categoryTotals);
+      this.renderMonthChart(monthTotals);
+    });
+  }
+
+  private renderCategoryChart(totals: { [key: string]: number }) {
+    const chart = new Chart('categoryChart', {
+      type: 'pie',
+      data: {
+        labels: Object.keys(totals),
+        datasets: [{ data: Object.values(totals) }]
+      },
+      options: {
+        onClick: (_e, els) => {
+          if (!els.length) return;
+          const index = els[0].index;
+          const label = Object.keys(totals)[index];
+          this.router.navigate(['/transactions'], {
+            queryParams: { category: label }
+          });
         }
-      });
+      }
+    });
+  }
+
+  private renderMonthChart(totals: { [key: string]: number }) {
+    const labels = Object.keys(totals).sort();
+    const data = labels.map(l => totals[l]);
+
+    new Chart('monthlyChart', {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [{ data, label: 'Total Spend' }]
+      },
+      options: {
+        onClick: (_e, els) => {
+          if (!els.length) return;
+          const index = els[0].index;
+          this.router.navigate(['/transactions'], {
+            queryParams: { month: labels[index] }
+          });
+        }
+      }
     });
   }
 }

--- a/frontend/src/app/pages/transactions/transactions.ts
+++ b/frontend/src/app/pages/transactions/transactions.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { ActivatedRoute } from '@angular/router';
 import { environment } from '../../../environments/environment';
 
 @Component({
@@ -12,12 +13,33 @@ import { environment } from '../../../environments/environment';
 })
 export class Transactions implements OnInit {
   transactions: any[] = [];
+  allTransactions: any[] = [];
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private route: ActivatedRoute) {}
 
   ngOnInit(): void {
     this.http.get<any[]>(`${environment.apiUrl}/transactions`).subscribe(res => {
-      this.transactions = res;
+      this.allTransactions = res;
+      this.applyFilters();
+      this.route.queryParams.subscribe(() => this.applyFilters());
     });
+  }
+
+  private applyFilters() {
+    const params = this.route.snapshot.queryParams;
+    let filtered = [...this.allTransactions];
+
+    if (params['category']) {
+      filtered = filtered.filter(t => {
+        const cat = (t.tags && t.tags.length) ? t.tags[0].name : 'Uncategorized';
+        return cat === params['category'];
+      });
+    }
+
+    if (params['month']) {
+      filtered = filtered.filter(t => (t.date as string).startsWith(params['month']));
+    }
+
+    this.transactions = filtered;
   }
 }


### PR DESCRIPTION
## Summary
- compute totals by tag and month in Dashboard
- display pie and line charts
- clicking a chart filters Transactions view

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e41a5cffc8320aca58a223ec60a1a