### PR TITLE
Implement monthly report endpoint

### DIFF
--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -4,6 +4,7 @@ from .auth import bp as auth_bp
 from .transactions import bp as transactions_bp
 from .tags import bp as tags_bp
 from .cardholders import bp as cardholders_bp
+from .reports import bp as reports_bp
 
 
 def register_blueprints(app: Blueprint) -> None:
@@ -12,3 +13,4 @@ def register_blueprints(app: Blueprint) -> None:
     app.register_blueprint(transactions_bp)
     app.register_blueprint(tags_bp)
     app.register_blueprint(cardholders_bp)
+    app.register_blueprint(reports_bp)

--- a/backend/app/routes/reports.py
+++ b/backend/app/routes/reports.py
@@ -1,0 +1,56 @@
+from calendar import monthrange
+from datetime import date
+import io
+
+from flask import Blueprint, render_template, request, send_file
+from weasyprint import HTML
+
+from ..models import Transaction
+
+bp = Blueprint('reports', __name__, url_prefix='/reports')
+
+
+@bp.route('/<month>', methods=['GET'])
+def monthly_report(month: str):
+    """Return an HTML or PDF spending report for the given month.
+
+    ``month`` is expected in ``YYYY-MM`` format.
+    """
+    try:
+        start = date.fromisoformat(f"{month}-01")
+    except ValueError:
+        return {"error": "invalid month"}, 400
+
+    last_day = monthrange(start.year, start.month)[1]
+    end = date(start.year, start.month, last_day)
+
+    transactions = (
+        Transaction.query
+        .filter(Transaction.transaction_date >= start)
+        .filter(Transaction.transaction_date <= end)
+        .all()
+    )
+
+    total = sum(float(t.total_amount or 0) for t in transactions)
+    by_cardholder = {}
+    for t in transactions:
+        name = t.cardholder_name or "Unknown"
+        by_cardholder[name] = by_cardholder.get(name, 0) + float(t.total_amount or 0)
+
+    html = render_template(
+        'report.html',
+        month=start.strftime('%B %Y'),
+        total=total,
+        by_cardholder=by_cardholder,
+        transactions=transactions,
+    )
+
+    if request.args.get('format') == 'pdf':
+        pdf_bytes = HTML(string=html).write_pdf()
+        return send_file(
+            io.BytesIO(pdf_bytes),
+            mimetype='application/pdf',
+            download_name=f'report-{month}.pdf'
+        )
+
+    return html

--- a/backend/app/templates/report.html
+++ b/backend/app/templates/report.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Report {{ month }}</title>
+    <style>
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #ccc; padding: 4px; }
+    </style>
+</head>
+<body>
+    <h1>Spending Report - {{ month }}</h1>
+    <p>Total Spend: {{ '%.2f'|format(total) }}</p>
+    <h2>By Cardholder</h2>
+    <ul>
+    {% for name, amount in by_cardholder.items() %}
+        <li>{{ name }}: {{ '%.2f'|format(amount) }}</li>
+    {% endfor %}
+    </ul>
+    <h2>Transactions</h2>
+    <table>
+        <thead>
+            <tr><th>Date</th><th>Description</th><th>Amount</th><th>Cardholder</th></tr>
+        </thead>
+        <tbody>
+        {% for tx in transactions %}
+            <tr>
+                <td>{{ tx.transaction_date }}</td>
+                <td>{{ tx.description }}</td>
+                <td>{{ tx.total_amount or 0 }}</td>
+                <td>{{ tx.cardholder_name }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ flask-migrate
 psycopg2-binary
 flask-cors
 pdfminer.six
+WeasyPrint

--- a/frontend/src/app/pages/report/report.html
+++ b/frontend/src/app/pages/report/report.html
@@ -1,1 +1,6 @@
-<p>report works!</p>
+<div class="container mt-4">
+  <div class="mb-3">
+    <a [href]="pdfUrl" class="btn btn-secondary">Download PDF</a>
+  </div>
+  <div [innerHTML]="html"></div>
+</div>

--- a/frontend/src/app/pages/report/report.ts
+++ b/frontend/src/app/pages/report/report.ts
@@ -1,13 +1,27 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { ActivatedRoute } from '@angular/router';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-report',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, HttpClientModule],
   templateUrl: './report.html',
   styleUrl: './report.scss'
 })
-export class Report {
+export class Report implements OnInit {
+  html = '';
+  pdfUrl = '';
 
+  constructor(private http: HttpClient, private route: ActivatedRoute) {}
+
+  ngOnInit(): void {
+    const month = this.route.snapshot.paramMap.get('month') ?? '';
+    this.pdfUrl = `${environment.apiUrl}/reports/${month}?format=pdf`;
+    this.http
+      .get(`${environment.apiUrl}/reports/${month}`, { responseType: 'text' })
+      .subscribe(res => (this.html = res));
+  }
 }

--- a/frontend/src/app/services/data.service.ts
+++ b/frontend/src/app/services/data.service.ts
@@ -13,4 +13,10 @@ export class DataService {
   createTransaction(payload: any) {
     return this.http.post(`${environment.apiUrl}/transactions`, payload);
   }
+
+  getReport(month: string) {
+    return this.http.get(`${environment.apiUrl}/reports/${month}`, {
+      responseType: 'text'
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- add `/reports/<month>` API with optional PDF output
- register reports blueprint
- create Jinja template for HTML reports
- include WeasyPrint in backend requirements
- implement Angular page to view and download reports
- expose report helper in `DataService`

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_687e41a9322483209b9028ad5035ae70