### PR TITLE
Implement cardholder auto-detection on PDF upload

### DIFF
--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -20,6 +20,8 @@ class Transaction(db.Model):
     currency = db.Column(db.String(10))
     is_credit = db.Column(db.Boolean, default=False)
     cardholder_name = db.Column(db.String(100))
+    cardholder_id = db.Column(db.Integer, db.ForeignKey('cardholder.id'))
+    cardholder = db.relationship('Cardholder', back_populates='transactions')
     source_file = db.Column(db.String(200))
 
     tags = db.relationship("Tag", secondary=transaction_tags, backref="transactions")

--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -5,6 +5,7 @@ from flask import Blueprint, request, jsonify
 from .. import db
 from ..models import Transaction
 from ..services.pdf_parser import parse_pdf
+from ..services.cardholder_mapping import guess_cardholder
 
 bp = Blueprint('transactions', __name__, url_prefix='/transactions')
 
@@ -15,9 +16,10 @@ def list_transactions():
     data = [
         {
             'id': t.id,
-            'date': t.date.isoformat(),
+            'transaction_date': t.transaction_date.isoformat(),
+            'posting_date': t.posting_date.isoformat() if t.posting_date else None,
             'description': t.description,
-            'amount': float(t.amount),
+            'total_amount': float(t.total_amount) if t.total_amount is not None else None,
             'cardholder_id': t.cardholder_id,
         }
         for t in transactions
@@ -29,9 +31,14 @@ def list_transactions():
 def create_transaction():
     payload = request.get_json() or {}
     transaction = Transaction(
-        date=date.fromisoformat(payload['date']),
+        transaction_date=date.fromisoformat(payload['transaction_date']),
+        posting_date=date.fromisoformat(payload['posting_date']) if payload.get('posting_date') else None,
         description=payload['description'],
-        amount=payload['amount'],
+        original_amount=payload.get('original_amount'),
+        vat=payload.get('vat'),
+        total_amount=payload.get('total_amount'),
+        currency=payload.get('currency'),
+        is_credit=payload.get('is_credit', False),
         cardholder_id=payload.get('cardholder_id'),
         source_file=payload.get('source_file'),
     )
@@ -53,11 +60,15 @@ def upload_pdf():
     transactions = parse_pdf(tmp_path)
     created = 0
     for data in transactions:
+        cardholder_id = guess_cardholder(data.get('description', ''), file.filename)
         transaction = Transaction(
-            date=data['date'],
+            transaction_date=data['transaction_date'],
+            posting_date=data.get('posting_date'),
             description=data['description'],
-            amount=data['amount'],
-            cardholder_id=data.get('cardholder_id'),
+            original_amount=data.get('original_amount'),
+            vat=data.get('vat'),
+            total_amount=data.get('total_amount'),
+            cardholder_id=cardholder_id,
             source_file=file.filename,
         )
         db.session.add(transaction)
@@ -65,3 +76,14 @@ def upload_pdf():
     db.session.commit()
 
     return jsonify({'created': created}), 201
+
+
+@bp.route('/<int:transaction_id>', methods=['PATCH'])
+def update_transaction(transaction_id: int):
+    """Update existing transaction fields."""
+    transaction = Transaction.query.get_or_404(transaction_id)
+    payload = request.get_json() or {}
+    if 'cardholder_id' in payload:
+        transaction.cardholder_id = payload['cardholder_id']
+    db.session.commit()
+    return jsonify({'id': transaction.id})

--- a/backend/app/services/cardholder_mapping.py
+++ b/backend/app/services/cardholder_mapping.py
@@ -1,0 +1,20 @@
+import re
+from typing import Optional
+
+# Map cardholder IDs to regex patterns that may appear in the
+# transaction description or the uploaded filename. Adjust these
+# patterns to match your actual statements.
+CARDHOLDER_PATTERNS = {
+    1: [re.compile(r"john", re.IGNORECASE)],
+    2: [re.compile(r"mary", re.IGNORECASE)],
+}
+
+
+def guess_cardholder(description: str, filename: str) -> Optional[int]:
+    """Attempt to determine the cardholder ID for a transaction."""
+    text = f"{description} {filename}"
+    for cid, patterns in CARDHOLDER_PATTERNS.items():
+        for pattern in patterns:
+            if pattern.search(text):
+                return cid
+    return None


### PR DESCRIPTION
## Summary
- add helper to guess cardholder from description or filename
- store cardholder_id in Transaction model
- parse PDF uploads using new fields and auto-assign cardholder
- expose PATCH /transactions/<id> for later manual adjustments

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687e41b341788320ad5cb6b256aa7e87