### PR TITLE
Initialize Flask-Migrate and add user name/username migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ This project is a mobile-first application to track and analyze monthly credit c
 1. Install Python dependencies:
    ```bash
    pip install -r backend/requirements.txt
+   ```
+2. Upgrade the database:
+   ```bash
+   flask --app backend/app/main.py db upgrade
+   ```
 3. Run the application:
 
    ```bash

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -2,6 +2,7 @@ from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_jwt_extended import JWTManager
 from flask_cors import CORS
+from flask_migrate import Migrate
 
 db = SQLAlchemy()
 jwt = JWTManager()
@@ -17,6 +18,7 @@ def create_app(config_object="app.config.Config"):
     CORS(app)
 
     db.init_app(app)
+    Migrate(app, db)
     jwt.init_app(app)
     register_blueprints(app)
 

--- a/backend/migrations/README
+++ b/backend/migrations/README
@@ -1,0 +1,1 @@
+Single-database configuration for Flask.

--- a/backend/migrations/alembic.ini
+++ b/backend/migrations/alembic.ini
@@ -1,0 +1,50 @@
+# A generic, single database configuration.
+
+[alembic]
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic,flask_migrate
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[logger_flask_migrate]
+level = INFO
+handlers =
+qualname = flask_migrate
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,0 +1,113 @@
+import logging
+from logging.config import fileConfig
+
+from flask import current_app
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+logger = logging.getLogger('alembic.env')
+
+
+def get_engine():
+    try:
+        # this works with Flask-SQLAlchemy<3 and Alchemical
+        return current_app.extensions['migrate'].db.get_engine()
+    except (TypeError, AttributeError):
+        # this works with Flask-SQLAlchemy>=3
+        return current_app.extensions['migrate'].db.engine
+
+
+def get_engine_url():
+    try:
+        return get_engine().url.render_as_string(hide_password=False).replace(
+            '%', '%%')
+    except AttributeError:
+        return str(get_engine().url).replace('%', '%%')
+
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+config.set_main_option('sqlalchemy.url', get_engine_url())
+target_db = current_app.extensions['migrate'].db
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def get_metadata():
+    if hasattr(target_db, 'metadatas'):
+        return target_db.metadatas[None]
+    return target_db.metadata
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=get_metadata(), literal_binds=True
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+
+    # this callback is used to prevent an auto-migration from being generated
+    # when there are no changes to the schema
+    # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
+    def process_revision_directives(context, revision, directives):
+        if getattr(config.cmd_opts, 'autogenerate', False):
+            script = directives[0]
+            if script.upgrade_ops.is_empty():
+                directives[:] = []
+                logger.info('No changes in schema detected.')
+
+    conf_args = current_app.extensions['migrate'].configure_args
+    if conf_args.get("process_revision_directives") is None:
+        conf_args["process_revision_directives"] = process_revision_directives
+
+    connectable = get_engine()
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=get_metadata(),
+            **conf_args
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/migrations/script.py.mako
+++ b/backend/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/backend/migrations/versions/add_name_and_username_to_user_add_name_and_username_to_user.py
+++ b/backend/migrations/versions/add_name_and_username_to_user_add_name_and_username_to_user.py
@@ -1,0 +1,30 @@
+"""Add name and username to User
+
+Revision ID: add_name_and_username_to_user
+Revises: 
+Create Date: 2025-07-21 19:02:00.814037
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'add_name_and_username_to_user'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user') as batch_op:
+        batch_op.add_column(sa.Column('name', sa.String(length=80), nullable=True))
+        batch_op.add_column(sa.Column('username', sa.String(length=80), nullable=True))
+        batch_op.create_unique_constraint('uq_user_username', ['username'])
+
+
+def downgrade():
+    with op.batch_alter_table('user') as batch_op:
+        batch_op.drop_constraint('uq_user_username', type_='unique')
+        batch_op.drop_column('username')
+        batch_op.drop_column('name')


### PR DESCRIPTION
## Summary
- enable Flask-Migrate in `create_app`
- add alembic migration to add `name` and `username` columns on `user`
- update README to instruct running migrations

## Testing
- `python -m py_compile backend/app/__init__.py`
- `flask --app app.main db upgrade`

------
https://chatgpt.com/codex/tasks/task_b_687e8df4a4dc8320b434058c6c474d14