### PR TITLE
Fix register_blueprints parameter type

### DIFF
--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
+from flask import Flask
 
 from .auth import bp as auth_bp
 from .transactions import bp as transactions_bp
@@ -7,7 +7,7 @@ from .cardholders import bp as cardholders_bp
 from .reports import bp as reports_bp
 
 
-def register_blueprints(app: Blueprint) -> None:
+def register_blueprints(app: Flask) -> None:
     """Register all route blueprints with the given Flask app."""
     app.register_blueprint(auth_bp)
     app.register_blueprint(transactions_bp)


### PR DESCRIPTION
## Summary
- change `register_blueprints` parameter to `Flask` for clarity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687e8e17e864832092bd2419be025cb7