### PR TITLE
Implement tag assignment when importing transactions

### DIFF
--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -6,6 +6,7 @@ from .. import db
 from ..models import Transaction, Tag
 from ..services.pdf_parser import parse_pdf
 from ..services.cardholder_mapping import guess_cardholder
+from ..services.tagging import assign_tags, DEFAULT_KEYWORDS
 
 bp = Blueprint('transactions', __name__, url_prefix='/transactions')
 
@@ -99,6 +100,7 @@ def upload_pdf():
             cardholder_id=cardholder_id,
             source_file=file.filename,
         )
+        transaction.tags = assign_tags(transaction, DEFAULT_KEYWORDS)
         db.session.add(transaction)
         created += 1
     db.session.commit()

--- a/backend/app/services/tagging.py
+++ b/backend/app/services/tagging.py
@@ -1,7 +1,58 @@
 """Utilities for assigning and managing tags."""
 
+from __future__ import annotations
 
-def assign_tags(transaction, keywords):
-    """Placeholder for tag assignment logic."""
-    # TODO: implement tagging based on keywords
-    return []
+from typing import Dict, Iterable, List, Union
+import re
+
+from ..models import Tag
+
+
+# Example keyword mapping. Keys may be tag names or IDs and values are lists of
+# keywords or regular expression patterns. This mapping can be overridden when
+# calling :func:`assign_tags`.
+DEFAULT_KEYWORDS: Dict[Union[int, str], Iterable[str]] = {
+    "Groceries": ["grocery", "supermarket", "market"],
+    "Fuel": ["fuel", "gas", "petrol", "shell"],
+}
+
+
+def _find_tag(tag_key: Union[int, str]) -> Tag | None:
+    """Return a ``Tag`` instance given an ID or name."""
+
+    if isinstance(tag_key, int):
+        return Tag.query.get(tag_key)
+    return Tag.query.filter_by(name=tag_key).first()
+
+
+def assign_tags(transaction, keywords: Dict[Union[int, str], Iterable[str]] | None = None) -> List[Tag]:
+    """Return a list of tags matching the transaction description.
+
+    Parameters
+    ----------
+    transaction:
+        ``Transaction`` instance containing the description.
+    keywords:
+        Mapping of tag identifiers (name or ID) to lists of keywords or regex
+        patterns. If ``None`` the :data:`DEFAULT_KEYWORDS` mapping is used.
+    """
+
+    keywords = keywords or DEFAULT_KEYWORDS
+    description = (transaction.description or "").lower()
+    matched: List[Tag] = []
+
+    for tag_key, patterns in keywords.items():
+        for pattern in patterns:
+            tag = None
+            if isinstance(pattern, re.Pattern):
+                if pattern.search(description):
+                    tag = _find_tag(tag_key)
+            else:
+                if str(pattern).lower() in description:
+                    tag = _find_tag(tag_key)
+
+            if tag and tag not in matched:
+                matched.append(tag)
+                break
+
+    return matched


### PR DESCRIPTION
## Summary
- add practical tag assignment logic in `assign_tags`
- auto-tag parsed transactions when uploading PDF statements

## Testing
- `flake8 backend/app/services/tagging.py backend/app/routes/transactions.py`
- `python -m py_compile backend/app/services/tagging.py backend/app/routes/transactions.py`


------
https://chatgpt.com/codex/tasks/task_b_687e8e1c3e008320835c75568c0d3297