### PR TITLE
Fix JWT subject type for login tokens

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -16,7 +16,11 @@ def login():
     data = request.get_json() or {}
     user = User.query.filter_by(email=data.get('email')).first()
     if user and check_password_hash(user.password, data.get('password', '')):
-        token = create_access_token(identity=user.id)
+        # ``flask_jwt_extended`` expects the subject claim to be a string.
+        # Using an integer ID directly can trigger "Subject must be a string"
+        # errors when the token is decoded. Cast the user ID to ``str`` to
+        # ensure compatibility.
+        token = create_access_token(identity=str(user.id))
         return jsonify({'access_token': token}), 200
     return jsonify({'error': 'invalid credentials'}), 401
 

--- a/backend/app/utils/auth.py
+++ b/backend/app/utils/auth.py
@@ -3,4 +3,6 @@ from flask_jwt_extended import create_access_token
 
 def generate_token(user_id):
     """Generate a JWT for the given user ID."""
-    return create_access_token(identity=user_id)
+    # ``flask_jwt_extended`` requires the subject claim to be a string.
+    # Casting ensures tokens are valid even if ``user_id`` is an integer.
+    return create_access_token(identity=str(user_id))


### PR DESCRIPTION
## Summary
- ensure `create_access_token` receives a string identity

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687ec556a6148320b2d6ad715bad4340