### PR TITLE
Add card number parsing and JSON import flow

### DIFF
--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -20,6 +20,7 @@ class Transaction(db.Model):
     currency = db.Column(db.String(10))
     is_credit = db.Column(db.Boolean, default=False)
     cardholder_name = db.Column(db.String(100))
+    card_number = db.Column(db.String(20))
     cardholder_id = db.Column(db.Integer, db.ForeignKey('cardholder.id'))
     cardholder = db.relationship('Cardholder', back_populates='transactions')
     source_file = db.Column(db.String(200))

--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -53,8 +53,12 @@ def list_transactions():
             'transaction_date': t.transaction_date.isoformat(),
             'posting_date': t.posting_date.isoformat() if t.posting_date else None,
             'description': t.description,
+            'original_amount': float(t.original_amount) if t.original_amount is not None else None,
+            'vat': float(t.vat) if t.vat is not None else None,
             'total_amount': float(t.total_amount) if t.total_amount is not None else None,
             'cardholder_id': t.cardholder_id,
+            'cardholder_name': t.cardholder_name,
+            'card_number': t.card_number,
         }
         for t in transactions
     ]
@@ -76,13 +80,33 @@ def create_transaction():
         total_amount=payload.get('total_amount'),
         currency=payload.get('currency'),
         is_credit=payload.get('is_credit', False),
+        card_number=payload.get('card_number'),
         cardholder_id=payload.get('cardholder_id'),
+        cardholder_name=payload.get('cardholder_name'),
         source_file=payload.get('source_file'),
     )
     db.session.add(transaction)
     db.session.commit()
     current_app.logger.info('Created transaction id=%s', transaction.id)
     return jsonify({'id': transaction.id}), 201
+
+
+@bp.route('/parse_pdf', methods=['POST'])
+@jwt_required()
+def parse_pdf_endpoint():
+    """Return parsed transactions from an uploaded PDF without saving."""
+    file = request.files.get('file')
+    current_app.logger.info('PDF parse request received: %s', file.filename if file else None)
+    if not file:
+        return jsonify({'error': 'no file uploaded'}), 400
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.pdf') as tmp:
+        file.save(tmp.name)
+        tmp_path = tmp.name
+
+    data = parse_pdf(tmp_path)
+    current_app.logger.debug('Parsed %d transactions from PDF', len(data))
+    return jsonify(data)
 
 
 @bp.route('/upload_pdf', methods=['POST'])
@@ -110,6 +134,8 @@ def upload_pdf():
             original_amount=data.get('original_amount'),
             vat=data.get('vat'),
             total_amount=data.get('total_amount'),
+            card_number=data.get('card_number'),
+            cardholder_name=data.get('cardholder_name'),
             cardholder_id=cardholder_id,
             source_file=file.filename,
         )
@@ -118,6 +144,37 @@ def upload_pdf():
         created += 1
     db.session.commit()
     current_app.logger.info('Created %d transactions from PDF %s', created, file.filename)
+    return jsonify({'created': created}), 201
+
+
+@bp.route('/batch', methods=['POST'])
+@jwt_required()
+def batch_create():
+    """Create multiple transactions from JSON payload."""
+    payload = request.get_json() or []
+    if not isinstance(payload, list):
+        return jsonify({'error': 'invalid payload'}), 400
+    created = 0
+    for item in payload:
+        try:
+            transaction = Transaction(
+                transaction_date=date.fromisoformat(item['transaction_date']),
+                posting_date=date.fromisoformat(item['posting_date']) if item.get('posting_date') else None,
+                description=item['description'],
+                original_amount=item.get('original_amount'),
+                vat=item.get('vat'),
+                total_amount=item.get('total_amount'),
+                card_number=item.get('card_number'),
+                cardholder_name=item.get('cardholder_name'),
+                source_file=item.get('source_file'),
+            )
+        except Exception as exc:
+            current_app.logger.error('Failed to parse item %s: %s', item, exc)
+            continue
+        db.session.add(transaction)
+        created += 1
+    db.session.commit()
+    current_app.logger.info('Batch created %d transactions', created)
     return jsonify({'created': created}), 201
 
 

--- a/backend/migrations/versions/add_card_number_to_transaction.py
+++ b/backend/migrations/versions/add_card_number_to_transaction.py
@@ -1,0 +1,33 @@
+"""Add card_number to transaction
+
+Revision ID: add_card_number_to_transaction
+Revises: fac9310bb1b4
+Create Date: 2025-08-30 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision = 'add_card_number_to_transaction'
+down_revision = 'fac9310bb1b4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    insp = inspect(bind)
+    cols = {c['name'] for c in insp.get_columns('transaction')}
+    with op.batch_alter_table('transaction') as batch_op:
+        if 'card_number' not in cols:
+            batch_op.add_column(sa.Column('card_number', sa.String(20)))
+
+
+def downgrade():
+    bind = op.get_bind()
+    insp = inspect(bind)
+    cols = {c['name'] for c in insp.get_columns('transaction')}
+    with op.batch_alter_table('transaction') as batch_op:
+        if 'card_number' in cols:
+            batch_op.drop_column('card_number')

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "bootstrap": "^5.3.3",
     "chart.js": "^4.4.1",
     "ng2-charts": "^4.0.0",
+    "file-saver": "^2.0.5",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { Login } from './pages/login/login';
 import { Dashboard } from './pages/dashboard/dashboard';
 import { Upload } from './pages/upload/upload';
+import { ImportJson } from './pages/import-json/import-json';
 import { Transactions } from './pages/transactions/transactions';
 import { AddTransaction } from './pages/add-transaction/add-transaction';
 import { Tags } from './pages/tags/tags';
@@ -14,6 +15,7 @@ export const routes: Routes = [
   { path: 'register', component: Register },
   { path: 'dashboard', component: Dashboard },
   { path: 'upload', component: Upload },
+  { path: 'import-json', component: ImportJson },
   { path: 'transactions/new', component: AddTransaction },
   { path: 'transactions', component: Transactions },
   { path: 'tags', component: Tags },

--- a/frontend/src/app/pages/add-transaction/add-transaction.html
+++ b/frontend/src/app/pages/add-transaction/add-transaction.html
@@ -14,6 +14,14 @@
       <input type="number" class="form-control" formControlName="total_amount" />
     </div>
     <div class="mb-3">
+      <label class="form-label">Card Number</label>
+      <input type="text" class="form-control" formControlName="card_number" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Cardholder Name</label>
+      <input type="text" class="form-control" formControlName="cardholder_name" />
+    </div>
+    <div class="mb-3">
       <label class="form-label">Cardholder ID</label>
       <input type="number" class="form-control" formControlName="cardholder_id" />
     </div>

--- a/frontend/src/app/pages/add-transaction/add-transaction.ts
+++ b/frontend/src/app/pages/add-transaction/add-transaction.ts
@@ -19,6 +19,8 @@ export class AddTransaction {
       transaction_date: '',
       description: '',
       total_amount: 0,
+      card_number: '',
+      cardholder_name: '',
       cardholder_id: '',
       source_file: ''
     });

--- a/frontend/src/app/pages/import-json/import-json.html
+++ b/frontend/src/app/pages/import-json/import-json.html
@@ -1,0 +1,11 @@
+<div class="container mt-4">
+  <h2>Import Transactions from JSON</h2>
+  <div class="mb-3">
+    <input type="file" (change)="onFile($event)" />
+  </div>
+  <div class="mb-3">
+    <textarea class="form-control" rows="10" [(ngModel)]="jsonText" (input)="parse()"></textarea>
+  </div>
+  <button class="btn btn-primary" (click)="submit()" [disabled]="!parsed.length">Submit</button>
+  <pre class="mt-3" *ngIf="parsed.length">{{ parsed | json }}</pre>
+</div>

--- a/frontend/src/app/pages/import-json/import-json.ts
+++ b/frontend/src/app/pages/import-json/import-json.ts
@@ -1,0 +1,45 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { DataService } from '../../services/data.service';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-import-json',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './import-json.html',
+  styleUrl: './import-json.scss'
+})
+export class ImportJson {
+  jsonText = '';
+  parsed: any[] = [];
+
+  constructor(private data: DataService, private router: Router) {}
+
+  onFile(event: Event) {
+    const input = event.target as HTMLInputElement;
+    if (!input.files || !input.files.length) return;
+    const file = input.files[0];
+    const reader = new FileReader();
+    reader.onload = () => {
+      this.jsonText = reader.result as string;
+      this.parse();
+    };
+    reader.readAsText(file);
+  }
+
+  parse() {
+    try {
+      this.parsed = JSON.parse(this.jsonText || '[]');
+    } catch {
+      this.parsed = [];
+    }
+  }
+
+  submit() {
+    this.data.batchCreateTransactions(this.parsed).subscribe(() => {
+      this.router.navigate(['/transactions']);
+    });
+  }
+}

--- a/frontend/src/app/pages/upload/upload.html
+++ b/frontend/src/app/pages/upload/upload.html
@@ -1,4 +1,5 @@
 <div class="container mt-4">
   <h2>Upload PDF Statement</h2>
   <input type="file" (change)="onFileSelected($event)" />
+  <pre class="mt-3" *ngIf="parsed.length">{{ parsed | json }}</pre>
 </div>

--- a/frontend/src/app/pages/upload/upload.ts
+++ b/frontend/src/app/pages/upload/upload.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
-import { AuthService } from '../../services/auth.service';
+import { HttpClientModule } from '@angular/common/http';
 import { Router } from '@angular/router';
-import { environment } from '../../../environments/environment';
+import { DataService } from '../../services/data.service';
+import { saveAs } from 'file-saver';
 
 @Component({
   selector: 'app-upload',
@@ -13,7 +13,8 @@ import { environment } from '../../../environments/environment';
   styleUrl: './upload.scss'
 })
 export class Upload {
-  constructor(private http: HttpClient, private router: Router, private auth: AuthService) {}
+  parsed: any[] = [];
+  constructor(private data: DataService, private router: Router) {}
 
   onFileSelected(event: Event) {
     const input = event.target as HTMLInputElement;
@@ -25,8 +26,10 @@ export class Upload {
     const formData = new FormData();
     formData.append('file', file);
 
-    this.http.post(`${environment.apiUrl}/transactions/upload_pdf`, formData, this.auth.authHeaders).subscribe(() => {
-      this.router.navigate(['/transactions']);
+    this.data.parsePdf(formData).subscribe(res => {
+      this.parsed = res;
+      const blob = new Blob([JSON.stringify(res, null, 2)], { type: 'application/json' });
+      saveAs(blob, 'transactions.json');
     });
   }
 }

--- a/frontend/src/app/services/data.service.ts
+++ b/frontend/src/app/services/data.service.ts
@@ -19,6 +19,14 @@ export class DataService {
     return this.http.post(`${environment.apiUrl}/transactions`, payload, this.headers);
   }
 
+  parsePdf(formData: FormData) {
+    return this.http.post<any[]>(`${environment.apiUrl}/transactions/parse_pdf`, formData, this.headers);
+  }
+
+  batchCreateTransactions(payload: any[]) {
+    return this.http.post(`${environment.apiUrl}/transactions/batch`, payload, this.headers);
+  }
+
   getReport(month: string) {
     return this.http.get(`${environment.apiUrl}/reports/${month}`, {
       responseType: 'text',


### PR DESCRIPTION
## Summary
- extend `Transaction` model with `card_number`
- parse card number and cardholder name in `pdf_parser`
- new endpoint `/transactions/parse_pdf` to return parsed JSON
- create `/transactions/batch` for importing transactions
- update PDF upload page to display & download JSON
- add page to import transactions from a JSON file or text
- include new DataService methods and route updates
- show card data in transaction list and add form inputs for card number/name

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npx ng build` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_b_688108acf85c8320a93a75def6d9db01