### PR TITLE
Expose more fields in transaction API

### DIFF
--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -56,6 +56,8 @@ def list_transactions():
             'original_amount': float(t.original_amount) if t.original_amount is not None else None,
             'vat': float(t.vat) if t.vat is not None else None,
             'total_amount': float(t.total_amount) if t.total_amount is not None else None,
+            'currency': t.currency,
+            'is_credit': t.is_credit,
             'cardholder_id': t.cardholder_id,
             'cardholder_name': t.cardholder_name,
             'card_number': t.card_number,

--- a/frontend/src/app/pages/transactions/transactions.html
+++ b/frontend/src/app/pages/transactions/transactions.html
@@ -28,16 +28,26 @@
       <tr>
         <th>Date</th>
         <th>Description</th>
-        <th>Total Amount</th>
+        <th>Original</th>
+        <th>VAT</th>
+        <th>Total</th>
+        <th>Currency</th>
+        <th>Credit?</th>
         <th>Cardholder</th>
+        <th>Card #</th>
       </tr>
     </thead>
     <tbody>
       <tr *ngFor="let t of transactions">
         <td>{{ t.transaction_date }}</td>
         <td>{{ t.description }}</td>
+        <td>{{ t.original_amount }}</td>
+        <td>{{ t.vat }}</td>
         <td>{{ t.total_amount }}</td>
-        <td>{{ t.cardholder_id }}</td>
+        <td>{{ t.currency }}</td>
+        <td>{{ t.is_credit ? 'Yes' : 'No' }}</td>
+        <td>{{ t.cardholder_name }}</td>
+        <td>{{ t.card_number }}</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
## Summary
- include currency and is_credit when listing transactions
- display the new transaction fields on the transaction list page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test --prefix frontend` *(fails: Could not find the '@angular/build:karma' builder's node package, then built with watch mode)*

------
https://chatgpt.com/codex/tasks/task_b_6883b01e2fb08320add7472d785d60a4