### PR TITLE
Add transaction detail endpoint

### DIFF
--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -4,6 +4,7 @@ from flask_jwt_extended import jwt_required
 
 from .. import db
 from ..models import Transaction, Tag
+from sqlalchemy.orm import joinedload
 import tempfile
 
 from ..services.pdf_parser import parse_pdf
@@ -181,6 +182,46 @@ def batch_create():
     return jsonify({'created': created}), 201
 
 
+@bp.route('/<int:transaction_id>', methods=['GET'])
+@jwt_required()
+def get_transaction(transaction_id: int):
+    """Return a single transaction with components and tags."""
+    current_app.logger.debug('Fetching transaction %s', transaction_id)
+    transaction = (
+        Transaction.query.options(
+            joinedload(Transaction.tags), joinedload(Transaction.components)
+        ).get_or_404(transaction_id)
+    )
+
+    data = {
+        'id': transaction.id,
+        'transaction_date': transaction.transaction_date.isoformat(),
+        'posting_date': transaction.posting_date.isoformat() if transaction.posting_date else None,
+        'description': transaction.description,
+        'original_amount': float(transaction.original_amount) if transaction.original_amount is not None else None,
+        'vat': float(transaction.vat) if transaction.vat is not None else None,
+        'total_amount': float(transaction.total_amount) if transaction.total_amount is not None else None,
+        'card_number': transaction.card_number,
+        'currency': transaction.currency,
+        'is_credit': transaction.is_credit,
+        'cardholder_id': transaction.cardholder_id,
+        'cardholder_name': transaction.cardholder_name,
+        'source_file': transaction.source_file,
+        'components': [
+            {
+                'id': c.id,
+                'label': c.label,
+                'amount': float(c.amount) if c.amount is not None else None,
+                'vat': float(c.vat) if c.vat is not None else None,
+            }
+            for c in transaction.components
+        ],
+        'tags': [{'id': t.id, 'name': t.name} for t in transaction.tags],
+    }
+
+    return jsonify(data)
+
+
 @bp.route('/<int:transaction_id>', methods=['PATCH'])
 @jwt_required()
 def update_transaction(transaction_id: int):
@@ -192,6 +233,19 @@ def update_transaction(transaction_id: int):
         transaction.cardholder_id = payload['cardholder_id']
     if 'card_number' in payload:
         transaction.card_number = payload['card_number']
+    if 'tags' in payload:
+        tags = Tag.query.filter(Tag.id.in_(payload['tags'])).all()
+        transaction.tags = tags
     db.session.commit()
     current_app.logger.info('Updated transaction id=%s', transaction.id)
     return jsonify({'id': transaction.id})
+
+
+@bp.route('/<int:transaction_id>/suggest-tags', methods=['GET'])
+@jwt_required()
+def suggest_tags(transaction_id: int):
+    """Return suggested tags for a transaction."""
+    current_app.logger.debug('Suggesting tags for transaction %s', transaction_id)
+    transaction = Transaction.query.get_or_404(transaction_id)
+    tags = assign_tags(transaction, DEFAULT_KEYWORDS)
+    return jsonify([{'id': t.id, 'name': t.name} for t in tags])

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { Upload } from './pages/upload/upload';
 import { ImportJson } from './pages/import-json/import-json';
 import { Transactions } from './pages/transactions/transactions';
 import { AddTransaction } from './pages/add-transaction/add-transaction';
+import { TransactionDetail } from './pages/transaction-detail/transaction-detail';
 import { Tags } from './pages/tags/tags';
 import { Report } from './pages/report/report';
 import { Home } from './pages/home/home';
@@ -18,6 +19,7 @@ export const routes: Routes = [
   { path: 'import-json', component: ImportJson },
   { path: 'transactions/new', component: AddTransaction },
   { path: 'transactions', component: Transactions },
+  { path: 'transactions/:id', component: TransactionDetail },
   { path: 'tags', component: Tags },
   { path: 'report/:month', component: Report },
   { path: '', component: Home }

--- a/frontend/src/app/pages/transaction-detail/transaction-detail.html
+++ b/frontend/src/app/pages/transaction-detail/transaction-detail.html
@@ -1,0 +1,32 @@
+<div class="container mt-4" *ngIf="transaction">
+  <h2>Transaction {{ transaction.id }}</h2>
+  <div class="mb-3">
+    <label class="form-label">Date</label>
+    <div>{{ transaction.transaction_date }}</div>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Description</label>
+    <div>{{ transaction.description }}</div>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Amount</label>
+    <div>{{ transaction.total_amount }}</div>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Tags</label>
+    <app-tag-tree [tags]="tags" [(selected)]="selected"></app-tag-tree>
+  </div>
+  <div class="mb-3 d-flex">
+    <input class="form-control me-2" [(ngModel)]="newTagName" placeholder="New tag name" />
+    <button class="btn btn-secondary" (click)="addTag()">Add Tag</button>
+  </div>
+  <div class="mb-3" *ngIf="suggested.length">
+    <label class="form-label">Suggested Tags:</label>
+    <div>
+      <button class="btn btn-sm btn-outline-primary me-1 mb-1" *ngFor="let t of suggested" (click)="applySuggested(t)">
+        {{ t.name }}
+      </button>
+    </div>
+  </div>
+  <button class="btn btn-primary" (click)="save()">Save</button>
+</div>

--- a/frontend/src/app/pages/transaction-detail/transaction-detail.scss
+++ b/frontend/src/app/pages/transaction-detail/transaction-detail.scss
@@ -1,0 +1,1 @@
+/* styles for transaction detail page */

--- a/frontend/src/app/pages/transaction-detail/transaction-detail.ts
+++ b/frontend/src/app/pages/transaction-detail/transaction-detail.ts
@@ -1,0 +1,64 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { DataService } from '../../services/data.service';
+import { TagService } from '../../services/tag.service';
+import { TagTree } from '../../components/tag-tree/tag-tree';
+import { Tag } from '../../models/tag';
+
+@Component({
+  selector: 'app-transaction-detail',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TagTree],
+  templateUrl: './transaction-detail.html',
+  styleUrl: './transaction-detail.scss'
+})
+export class TransactionDetail implements OnInit {
+  transaction: any;
+  tags: Tag[] = [];
+  selected: number[] = [];
+  suggested: Tag[] = [];
+  newTagName = '';
+
+  constructor(
+    private data: DataService,
+    private tagService: TagService,
+    private route: ActivatedRoute
+  ) {}
+
+  ngOnInit() {
+    const id = Number(this.route.snapshot.params['id']);
+    this.load(id);
+  }
+
+  load(id: number) {
+    this.data.getTransaction(id).subscribe(tx => {
+      this.transaction = tx;
+      this.selected = tx.tags ? tx.tags.map((t: any) => t.id) : [];
+      this.data.suggestTags(id).subscribe(s => (this.suggested = s));
+    });
+    this.tagService.getTags().subscribe(t => (this.tags = t));
+  }
+
+  addTag() {
+    if (!this.newTagName.trim()) return;
+    this.tagService.createTag({ name: this.newTagName }).subscribe(() => {
+      this.newTagName = '';
+      this.tagService.getTags().subscribe(t => (this.tags = t));
+    });
+  }
+
+  applySuggested(tag: Tag) {
+    if (!this.selected.includes(tag.id)) {
+      this.selected = [...this.selected, tag.id];
+    }
+  }
+
+  save() {
+    if (!this.transaction) return;
+    this.data
+      .updateTransaction(this.transaction.id, { tags: this.selected })
+      .subscribe(() => this.load(this.transaction.id));
+  }
+}

--- a/frontend/src/app/pages/transactions/transactions.html
+++ b/frontend/src/app/pages/transactions/transactions.html
@@ -38,7 +38,7 @@
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let t of transactions">
+      <tr *ngFor="let t of transactions" [routerLink]="['/transactions', t.id]" style="cursor: pointer;">
         <td>{{ t.transaction_date }}</td>
         <td>{{ t.description }}</td>
         <td>{{ t.original_amount }}</td>

--- a/frontend/src/app/services/data.service.ts
+++ b/frontend/src/app/services/data.service.ts
@@ -27,6 +27,18 @@ export class DataService {
     return this.http.post(`${environment.apiUrl}/transactions/batch`, payload, this.headers);
   }
 
+  getTransaction(id: number) {
+    return this.http.get<any>(`${environment.apiUrl}/transactions/${id}`, this.headers);
+  }
+
+  updateTransaction(id: number, payload: any) {
+    return this.http.patch(`${environment.apiUrl}/transactions/${id}`, payload, this.headers);
+  }
+
+  suggestTags(id: number) {
+    return this.http.get<any[]>(`${environment.apiUrl}/transactions/${id}/suggest-tags`, this.headers);
+  }
+
   getReport(month: string) {
     return this.http.get(`${environment.apiUrl}/reports/${month}`, {
       responseType: 'text',


### PR DESCRIPTION
## Summary
- expand transactions API for tag updates and suggestions
- expose frontend methods for transaction details
- add TransactionDetail page and routing
- link transaction rows to detail view

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68868dad253483208b5a88022a735834