### PR TITLE
Implement home redirect to login or dashboard

### DIFF
--- a/frontend/src/app/pages/dashboard/dashboard.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Router,RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { DataService } from '../../services/data.service';
+import { AuthService } from '../../services/auth.service';
 import Chart from 'chart.js/auto';
 
 @Component({
@@ -12,9 +13,17 @@ import Chart from 'chart.js/auto';
   styleUrl: './dashboard.scss'
 })
 export class Dashboard implements OnInit {
-  constructor(private data: DataService, private router: Router) {}
+  constructor(
+    private data: DataService,
+    private router: Router,
+    private auth: AuthService
+  ) {}
 
   ngOnInit(): void {
+    if (!this.auth.token) {
+      this.router.navigate(['/']);
+      return;
+    }
     this.data.getTransactions().subscribe(transactions => {
       const categoryTotals: { [key: string]: number } = {};
       const monthTotals: { [key: string]: number } = {};

--- a/frontend/src/app/pages/home/home.ts
+++ b/frontend/src/app/pages/home/home.ts
@@ -1,12 +1,21 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
+import { Router } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule],
   templateUrl: './home.html',
   styleUrl: './home.scss'
 })
-export class Home {}
+export class Home implements OnInit {
+  constructor(private auth: AuthService, private router: Router) {}
+
+  ngOnInit(): void {
+    if (this.auth.token) {
+      this.router.navigate(['/dashboard']);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- restore home page links to login or register
- check for JWT token on the Home page and skip redirect if not logged in
- protect Dashboard by redirecting to the Home page when no token is present

## Testing
- `npm test -- --watch=false` *(fails: Chrome binary not found)*

------
https://chatgpt.com/codex/tasks/task_b_68873e4e2c948320988541cea1a250ba