### PR TITLE
Add AI-powered tag suggestions

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -10,6 +10,7 @@ db = SQLAlchemy()
 jwt = JWTManager()
 
 from .routes import register_blueprints
+from .services.tag_ai import schedule_training, tag_ai
 
 
 def create_app(config_object="app.config.Config"):
@@ -26,5 +27,13 @@ def create_app(config_object="app.config.Config"):
     Migrate(app, db)
     jwt.init_app(app)
     register_blueprints(app)
+
+    # Train tag AI in the background using existing transactions
+    with app.app_context():
+        try:
+            tag_ai.train()
+        except Exception:  # pragma: no cover - startup training errors
+            app.logger.exception("Initial TagAI training failed")
+    schedule_training(app)
 
     return app

--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -10,6 +10,7 @@ import tempfile
 from ..services.pdf_parser import parse_pdf
 from ..services.cardholder_mapping import guess_cardholder
 from ..services.tagging import assign_tags, DEFAULT_KEYWORDS
+from ..services.tag_ai import tag_ai
 
 bp = Blueprint('transactions', __name__, url_prefix='/transactions')
 
@@ -249,3 +250,13 @@ def suggest_tags(transaction_id: int):
     transaction = Transaction.query.get_or_404(transaction_id)
     tags = assign_tags(transaction, DEFAULT_KEYWORDS)
     return jsonify([{'id': t.id, 'name': t.name} for t in tags])
+
+
+@bp.route('/<int:transaction_id>/ai-tags', methods=['GET'])
+@jwt_required()
+def ai_tags(transaction_id: int):
+    """Return AI-ranked tag suggestions for a transaction."""
+    current_app.logger.debug('AI suggesting tags for transaction %s', transaction_id)
+    transaction = Transaction.query.get_or_404(transaction_id)
+    suggestions = tag_ai.suggest(transaction.description)
+    return jsonify(suggestions)

--- a/backend/app/services/tag_ai.py
+++ b/backend/app/services/tag_ai.py
@@ -1,0 +1,93 @@
+"""AI-powered tag suggestions using scikit-learn."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import List, Dict
+
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.linear_model import LogisticRegression
+from sklearn.multioutput import MultiOutputClassifier
+
+from ..models import Transaction, Tag
+
+
+class TagAI:
+    """Train a model to predict tags from transaction descriptions."""
+
+    def __init__(self) -> None:
+        self.vectorizer = TfidfVectorizer(stop_words="english")
+        self.classifier = MultiOutputClassifier(LogisticRegression(max_iter=1000))
+        self.tag_ids: List[int] = []
+        self.trained = False
+
+    def train(self) -> None:
+        """Gather training data from existing transactions and fit the model."""
+        transactions = Transaction.query.join(Transaction.tags).all()
+        texts: List[str] = []
+        labels: List[List[int]] = []
+
+        tags = Tag.query.all()
+        self.tag_ids = [t.id for t in tags]
+        tag_index: Dict[int, int] = {tid: i for i, tid in enumerate(self.tag_ids)}
+
+        for tx in transactions:
+            if not tx.description:
+                continue
+            texts.append(tx.description)
+            row = [0] * len(self.tag_ids)
+            for tag in tx.tags:
+                idx = tag_index.get(tag.id)
+                if idx is not None:
+                    row[idx] = 1
+            labels.append(row)
+
+        if not texts:
+            logging.warning("TagAI: no training data available")
+            return
+
+        X = self.vectorizer.fit_transform(texts)
+        y = np.array(labels)
+        self.classifier.fit(X, y)
+        self.trained = True
+        logging.info("TagAI: trained on %d transactions", len(texts))
+
+    def suggest(self, description: str, top_n: int = 5) -> List[Dict[str, float]]:
+        """Return top-N tag suggestions for the given description."""
+        if not self.trained or not description:
+            return []
+        X = self.vectorizer.transform([description])
+        probas = self.classifier.predict_proba(X)
+        scores = [p[1] for p in probas]
+        ranked = np.argsort(scores)[::-1]
+        suggestions = []
+        for idx in ranked[:top_n]:
+            score = float(scores[idx])
+            if score <= 0:
+                continue
+            tag = Tag.query.get(self.tag_ids[idx])
+            if tag:
+                suggestions.append({"id": tag.id, "name": tag.name, "score": score})
+        return suggestions
+
+
+tag_ai = TagAI()
+
+
+def schedule_training(app, interval: int = 3600) -> None:
+    """Start a background thread that periodically retrains the model."""
+
+    def run():
+        while True:
+            with app.app_context():
+                try:
+                    tag_ai.train()
+                except Exception as exc:  # pragma: no cover - background logging
+                    logging.exception("TagAI training failed: %s", exc)
+            time.sleep(interval)
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ psycopg2-binary
 flask-cors
 pdfminer.six
 reportlab
+scikit-learn

--- a/frontend/src/app/components/tag-tree/tag-tree.html
+++ b/frontend/src/app/components/tag-tree/tag-tree.html
@@ -1,4 +1,12 @@
 <ul class="list-unstyled ms-3">
+  <li *ngIf="suggestions.length" class="mb-2">
+    <div class="fw-bold">Suggestions</div>
+    <div *ngFor="let s of suggestions" class="d-flex align-items-center mb-1">
+      <span class="flex-grow-1">{{ s.name }}</span>
+      <button class="btn btn-sm btn-primary me-1" (click)="acceptSuggestion(s)">Accept</button>
+      <button class="btn btn-sm btn-outline-secondary" (click)="ignoreSuggestion(s)">Ignore</button>
+    </div>
+  </li>
   <li *ngFor="let tag of tags" class="mb-1">
     <div class="d-flex align-items-center">
       <input type="checkbox" class="form-check-input me-2" [checked]="selected.includes(tag.id)" (change)="toggle(tag.id)" />

--- a/frontend/src/app/components/tag-tree/tag-tree.ts
+++ b/frontend/src/app/components/tag-tree/tag-tree.ts
@@ -12,9 +12,12 @@ import { Tag } from '../../models/tag';
 export class TagTree {
   @Input() tags: Tag[] = [];
   @Input() selected: number[] = [];
+  @Input() suggestions: Tag[] = [];
   @Output() selectedChange = new EventEmitter<number[]>();
   @Output() edit = new EventEmitter<Tag>();
   @Output() remove = new EventEmitter<Tag>();
+  @Output() accept = new EventEmitter<Tag>();
+  @Output() ignore = new EventEmitter<Tag>();
 
   toggle(id: number) {
     if (this.selected.includes(id)) {
@@ -23,5 +26,13 @@ export class TagTree {
       this.selected = [...this.selected, id];
     }
     this.selectedChange.emit(this.selected);
+  }
+
+  acceptSuggestion(tag: Tag) {
+    this.accept.emit(tag);
+  }
+
+  ignoreSuggestion(tag: Tag) {
+    this.ignore.emit(tag);
   }
 }

--- a/frontend/src/app/pages/transaction-detail/transaction-detail.html
+++ b/frontend/src/app/pages/transaction-detail/transaction-detail.html
@@ -14,19 +14,11 @@
   </div>
   <div class="mb-3">
     <label class="form-label">Tags</label>
-    <app-tag-tree [tags]="tags" [(selected)]="selected"></app-tag-tree>
+    <app-tag-tree [tags]="tags" [(selected)]="selected" [suggestions]="suggested" (accept)="applySuggested($event)" (ignore)="ignoreSuggested($event)"></app-tag-tree>
   </div>
   <div class="mb-3 d-flex">
     <input class="form-control me-2" [(ngModel)]="newTagName" placeholder="New tag name" />
     <button class="btn btn-secondary" (click)="addTag()">Add Tag</button>
-  </div>
-  <div class="mb-3" *ngIf="suggested.length">
-    <label class="form-label">Suggested Tags:</label>
-    <div>
-      <button class="btn btn-sm btn-outline-primary me-1 mb-1" *ngFor="let t of suggested" (click)="applySuggested(t)">
-        {{ t.name }}
-      </button>
-    </div>
   </div>
   <button class="btn btn-primary" (click)="save()">Save</button>
 </div>

--- a/frontend/src/app/pages/transaction-detail/transaction-detail.ts
+++ b/frontend/src/app/pages/transaction-detail/transaction-detail.ts
@@ -36,7 +36,7 @@ export class TransactionDetail implements OnInit {
     this.data.getTransaction(id).subscribe(tx => {
       this.transaction = tx;
       this.selected = tx.tags ? tx.tags.map((t: any) => t.id) : [];
-      this.data.suggestTags(id).subscribe(s => (this.suggested = s));
+      this.data.aiTags(id).subscribe(s => (this.suggested = s));
     });
     this.tagService.getTags().subscribe(t => (this.tags = t));
   }
@@ -53,6 +53,10 @@ export class TransactionDetail implements OnInit {
     if (!this.selected.includes(tag.id)) {
       this.selected = [...this.selected, tag.id];
     }
+  }
+
+  ignoreSuggested(tag: Tag) {
+    this.suggested = this.suggested.filter(t => t.id !== tag.id);
   }
 
   save() {

--- a/frontend/src/app/services/data.service.ts
+++ b/frontend/src/app/services/data.service.ts
@@ -39,6 +39,10 @@ export class DataService {
     return this.http.get<any[]>(`${environment.apiUrl}/transactions/${id}/suggest-tags`, this.headers);
   }
 
+  aiTags(id: number) {
+    return this.http.get<any[]>(`${environment.apiUrl}/transactions/${id}/ai-tags`, this.headers);
+  }
+
   getReport(month: string) {
     return this.http.get(`${environment.apiUrl}/reports/${month}`, {
       responseType: 'text',


### PR DESCRIPTION
## Summary
- Train a scikit-learn model in the background to suggest tags from transaction descriptions.
- Expose `/transactions/:id/ai-tags` to return ranked suggestions.
- Show tag suggestions in the tag tree with accept/ignore actions on the transaction detail page.

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_b_6892e37ec6ac8320beaf69adaec83d0a