### PR TITLE
feat: add CSV import and export

### DIFF
--- a/backend/app/routes/transactions.py
+++ b/backend/app/routes/transactions.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from flask import Blueprint, request, jsonify, current_app
+from flask import Blueprint, request, jsonify, current_app, Response
 from flask_jwt_extended import jwt_required
 
 from .. import db
@@ -10,6 +10,7 @@ import tempfile
 from ..services.pdf_parser import parse_pdf
 from ..services.cardholder_mapping import guess_cardholder
 from ..services.tagging import assign_tags, DEFAULT_KEYWORDS
+from ..services.import_export import export_transactions, import_transactions
 
 bp = Blueprint('transactions', __name__, url_prefix='/transactions')
 
@@ -180,6 +181,34 @@ def batch_create():
     db.session.commit()
     current_app.logger.info('Batch created %d transactions', created)
     return jsonify({'created': created}), 201
+
+
+@bp.route('/export', methods=['GET'])
+@jwt_required()
+def export_csv():
+    """Download all transactions as CSV."""
+    csv_data = export_transactions()
+    current_app.logger.info('Exporting transactions to CSV')
+    return Response(
+        csv_data,
+        mimetype='text/csv',
+        headers={'Content-Disposition': 'attachment; filename=transactions.csv'},
+    )
+
+
+@bp.route('/import', methods=['POST'])
+@jwt_required()
+def import_csv():
+    """Import transactions from a CSV upload."""
+    file = request.files.get('file')
+    if not file:
+        return jsonify({'error': 'no file uploaded'}), 400
+    count, errors = import_transactions(file)
+    if errors:
+        current_app.logger.warning('Import failed with errors: %s', errors)
+        return jsonify({'errors': errors}), 400
+    current_app.logger.info('Imported %d transactions from CSV', count)
+    return jsonify({'imported': count}), 201
 
 
 @bp.route('/<int:transaction_id>', methods=['GET'])

--- a/backend/app/services/import_export.py
+++ b/backend/app/services/import_export.py
@@ -1,0 +1,114 @@
+import csv
+import io
+from datetime import datetime
+from typing import Tuple, List
+
+from .. import db
+from ..models import Transaction
+
+REQUIRED_FIELDS = ["transaction_date", "description", "total_amount"]
+
+
+def export_transactions() -> str:
+    """Return all transactions as CSV text."""
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow([
+        "transaction_date",
+        "posting_date",
+        "description",
+        "original_amount",
+        "vat",
+        "total_amount",
+        "currency",
+        "is_credit",
+        "cardholder_name",
+        "card_number",
+        "cardholder_id",
+    ])
+
+    for t in Transaction.query.all():
+        writer.writerow([
+            t.transaction_date.isoformat(),
+            t.posting_date.isoformat() if t.posting_date else "",
+            t.description,
+            str(t.original_amount) if t.original_amount is not None else "",
+            str(t.vat) if t.vat is not None else "",
+            str(t.total_amount) if t.total_amount is not None else "",
+            t.currency or "",
+            str(t.is_credit),
+            t.cardholder_name or "",
+            t.card_number or "",
+            t.cardholder_id or "",
+        ])
+    return output.getvalue()
+
+
+def import_transactions(file) -> Tuple[int, List[str]]:
+    """Import transactions from an uploaded CSV file.
+
+    Returns a tuple of (count, errors). If errors is non-empty, no data is committed.
+    """
+    text = file.read().decode("utf-8")
+    reader = csv.DictReader(io.StringIO(text))
+    errors: List[str] = []
+    transactions = []
+
+    for i, row in enumerate(reader, start=1):
+        missing = [f for f in REQUIRED_FIELDS if not row.get(f)]
+        if missing:
+            errors.append(f"row {i}: missing fields {', '.join(missing)}")
+            continue
+        try:
+            transaction_date = datetime.fromisoformat(row["transaction_date"]).date()
+        except Exception:
+            errors.append(f"row {i}: invalid transaction_date")
+            continue
+        posting_date = None
+        if row.get("posting_date"):
+            try:
+                posting_date = datetime.fromisoformat(row["posting_date"]).date()
+            except Exception:
+                errors.append(f"row {i}: invalid posting_date")
+                continue
+        try:
+            total_amount = float(row["total_amount"])
+        except Exception:
+            errors.append(f"row {i}: invalid total_amount")
+            continue
+
+        def parse_optional_float(key: str):
+            try:
+                return float(row[key]) if row.get(key) else None
+            except Exception:
+                errors.append(f"row {i}: invalid {key}")
+                return None
+
+        original_amount = parse_optional_float("original_amount")
+        vat = parse_optional_float("vat")
+
+        if any(err.startswith(f"row {i}:") for err in errors):
+            continue
+
+        transaction = Transaction(
+            transaction_date=transaction_date,
+            posting_date=posting_date,
+            description=row["description"],
+            original_amount=original_amount,
+            vat=vat,
+            total_amount=total_amount,
+            currency=row.get("currency"),
+            is_credit=row.get("is_credit") == "True",
+            cardholder_name=row.get("cardholder_name"),
+            card_number=row.get("card_number"),
+            cardholder_id=int(row["cardholder_id"]) if row.get("cardholder_id") else None,
+        )
+        transactions.append(transaction)
+
+    if errors:
+        return 0, errors
+
+    for t in transactions:
+        db.session.add(t)
+    db.session.commit()
+    return len(transactions), []

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { Login } from './pages/login/login';
 import { Dashboard } from './pages/dashboard/dashboard';
 import { Upload } from './pages/upload/upload';
 import { ImportJson } from './pages/import-json/import-json';
+import { ImportExport } from './pages/import-export/import-export';
 import { Transactions } from './pages/transactions/transactions';
 import { AddTransaction } from './pages/add-transaction/add-transaction';
 import { TransactionDetail } from './pages/transaction-detail/transaction-detail';
@@ -17,6 +18,7 @@ export const routes: Routes = [
   { path: 'dashboard', component: Dashboard },
   { path: 'upload', component: Upload },
   { path: 'import-json', component: ImportJson },
+  { path: 'import-export', component: ImportExport },
   { path: 'transactions/new', component: AddTransaction },
   { path: 'transactions', component: Transactions },
   { path: 'transactions/:id', component: TransactionDetail },

--- a/frontend/src/app/pages/import-export/import-export.html
+++ b/frontend/src/app/pages/import-export/import-export.html
@@ -1,0 +1,8 @@
+<div class="container mt-4">
+  <h1>Import / Export Transactions</h1>
+  <div class="mb-3">
+    <label for="csvFile" class="form-label">Import CSV</label>
+    <input id="csvFile" type="file" class="form-control" (change)="onFile($event)" accept=".csv" />
+  </div>
+  <button class="btn btn-primary" (click)="export()">Export CSV</button>
+</div>

--- a/frontend/src/app/pages/import-export/import-export.scss
+++ b/frontend/src/app/pages/import-export/import-export.scss
@@ -1,0 +1,1 @@
+// styles for import/export page

--- a/frontend/src/app/pages/import-export/import-export.ts
+++ b/frontend/src/app/pages/import-export/import-export.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DataService } from '../../services/data.service';
+import { saveAs } from 'file-saver';
+
+@Component({
+  selector: 'app-import-export',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './import-export.html',
+  styleUrl: './import-export.scss'
+})
+export class ImportExport {
+  constructor(private data: DataService) {}
+
+  onFile(event: Event) {
+    const input = event.target as HTMLInputElement;
+    if (!input.files || !input.files.length) return;
+    const formData = new FormData();
+    formData.append('file', input.files[0]);
+    this.data.importTransactions(formData).subscribe();
+  }
+
+  export() {
+    this.data.exportTransactions().subscribe(blob => {
+      saveAs(blob, 'transactions.csv');
+    });
+  }
+}

--- a/frontend/src/app/services/data.service.ts
+++ b/frontend/src/app/services/data.service.ts
@@ -27,6 +27,17 @@ export class DataService {
     return this.http.post(`${environment.apiUrl}/transactions/batch`, payload, this.headers);
   }
 
+  importTransactions(formData: FormData) {
+    return this.http.post(`${environment.apiUrl}/transactions/import`, formData, this.headers);
+  }
+
+  exportTransactions() {
+    return this.http.get(`${environment.apiUrl}/transactions/export`, {
+      responseType: 'blob',
+      ...this.headers
+    });
+  }
+
   getTransaction(id: number) {
     return this.http.get<any>(`${environment.apiUrl}/transactions/${id}`, this.headers);
   }


### PR DESCRIPTION
## Summary
- add CSV import/export service and endpoints for transactions
- create Angular page for importing and exporting transaction CSV files
- extend data service for new APIs

## Testing
- `pytest`
- `npm test` *(fails: No binary for Chrome browser on your platform.)*

------
https://chatgpt.com/codex/tasks/task_b_6892e354e2bc832083252396740d0d4b